### PR TITLE
Change module path to github.com/gridscale/gscloud

### DIFF
--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	"gitlab.com/gridscale/gscloud/endpoints"
+	"github.com/gridscale/gscloud/endpoints"
 )
 
 // clusterCmd represents the cluster command

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gitlab.com/gridscale/gscloud
+module github.com/gridscale/gscloud
 
 go 1.13
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "gitlab.com/gridscale/gscloud/cmd"
+import "github.com/gridscale/gscloud/cmd"
 
 func main() {
 	cmd.Execute()

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -561,5 +561,5 @@
 			"revisionTime": "2019-07-04T18:38:35Z"
 		}
 	],
-	"rootPath": "gitlab.com/gridscale/gscloud"
+	"rootPath": "github.com/gridscale/gscloud"
 }


### PR DESCRIPTION
Just figured that this is still from public GitLab instance. This PR changes the module path from gitlab.com/gridscale/gscloud → to github.com.