### PR TITLE
Changed text for gscloud --help

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,22 +6,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// GitCommit gets its vlaue later
+// GitCommit gets its value through Makefile
 var GitCommit string
 
-// Version gets its value later
+// Version gets its value through Makefile
 var Version string
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Returns last Git Commit and Version",
+	Long: `gscloud version displays latest Git commit SHA and Version number.
+	
+For example:
+./gscloud version
+Version:        0.2.0-beta
+Git commit:     66a9631ed5c1516d34ca305d4432149b67675cd0`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("Version:\t%s\nGit commit:\t%s\n", Version, GitCommit)
 	},


### PR DESCRIPTION
gscloud version displays latest Git commit SHA and Version number.

For example:
./gscloud version
Version:        0.2.0-beta
Git commit:     66a9631ed5c1516d34ca305d4432149b67675cd0

https://gridscale.atlassian.net/browse/GD-2675