### PR TITLE
SSH key Management for gscloud

### DIFF
--- a/cmd/network.go
+++ b/cmd/network.go
@@ -22,7 +22,7 @@ var networkCmd = &cobra.Command{
 		}
 		var networkinfos [][]string
 		if !jsonFlag {
-			heading := []string{"name", "location", "createtime", "status", "uuid"}
+			heading := []string{"name", "location", "createtime", "status", "id"}
 			for _, netw := range networks {
 				fill := [][]string{
 					{

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -24,7 +24,7 @@ var serverCmd = &cobra.Command{
 		}
 		var serverinfos [][]string
 		if !jsonFlag {
-			heading := []string{"name", "core", "mem", "power", "uuid"}
+			heading := []string{"name", "core", "mem", "power", "id"}
 			for _, server := range servers {
 				status := "off"
 				if server.Properties.Power {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -10,13 +10,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var forceFlag bool
+
 var serverCmd = &cobra.Command{
 	Use:   "server",
 	Short: "Print server list",
 	Long:  `Print all server information`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-
 		out := new(bytes.Buffer)
 		servers, err := client.GetServerList(ctx)
 		if err != nil {
@@ -40,13 +41,11 @@ var serverCmd = &cobra.Command{
 					},
 				}
 				serverinfos = append(serverinfos, fill...)
-
 			}
 			if idFlag {
 				rowsToDisplay = len(heading)
 			}
 			render.Table(out, heading[:rowsToDisplay], serverinfos)
-
 		} else {
 			render.AsJSON(out, servers)
 		}
@@ -54,6 +53,29 @@ var serverCmd = &cobra.Command{
 	},
 }
 
+var onCmd, offCmd = &cobra.Command{
+	Use:   "on",
+	Short: "Turn server on",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
+		client.StartServer(ctx, args[0])
+	},
+}, &cobra.Command{
+	Use:   "off",
+	Short: "Turn server off",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
+		if forceFlag {
+			client.StopServer(ctx, args[0])
+		}
+		client.ShutdownServer(ctx, args[0])
+	},
+}
+
 func init() {
+	serverCmd.AddCommand(onCmd, offCmd)
+	serverCmd.PersistentFlags().BoolVarP(&forceFlag, "force", "f", false, "Force shutdown")
 	rootCmd.AddCommand(serverCmd)
 }

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -23,7 +23,7 @@ var storageCmd = &cobra.Command{
 		}
 		var storage [][]string
 		if !jsonFlag {
-			heading := []string{"name", "capacity", "changetime", "status", "uuid"}
+			heading := []string{"name", "capacity", "changetime", "status", "id"}
 			for _, stor := range storages {
 				fill := [][]string{
 					{


### PR DESCRIPTION
- Easy add your keys via file and give it an alias/name
- To remove a key, all you need is it's ID or NAME

Examples:
$ ./gscloud ssh-key
$ ./gscloud ssh-key --id
$ ./gscloud ssh-key add --name <name/alias> --file <path/to/file>
$ ./gscloud ssh-key remove --name <[alias]or[uuid]>
```
Fixes https://github.com/gridscale/gscloud/issues/30