### PR TITLE
SSH-Key Management

### DIFF
--- a/cmd/network.go
+++ b/cmd/network.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/gridscale/gscloud/render"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +19,8 @@ var networkCmd = &cobra.Command{
 		out := new(bytes.Buffer)
 		networks, err := client.GetNetworkList(ctx)
 		if err != nil {
-			panic(err)
+			log.Error("Couldn't get Networkinfo", err)
+			return
 		}
 		var networkinfos [][]string
 		if !jsonFlag {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/gridscale/gscloud/render"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +22,8 @@ var serverCmd = &cobra.Command{
 		out := new(bytes.Buffer)
 		servers, err := client.GetServerList(ctx)
 		if err != nil {
-			panic(err)
+			log.Error("Couldn't get Serverinfo", err)
+			return
 		}
 		var serverinfos [][]string
 		if !jsonFlag {

--- a/cmd/sshKey.go
+++ b/cmd/sshKey.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/gridscale/gsclient-go/v3"
+	"github.com/gridscale/gscloud/render"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+)
+
+var (
+	nameFlag, fileFlag bool
+)
+var sshKeyCmd = &cobra.Command{
+	Use:   "ssh-key",
+	Short: "Print ssh-key list",
+	Long:  `Print all ssh-key information`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
+		out := new(bytes.Buffer)
+		sshkeys, err := client.GetSshkeyList(ctx)
+		if err != nil {
+			log.Error("Couldn't get SSH-keys:", err)
+			return
+		}
+		var sshkeyinfo [][]string
+		if !jsonFlag {
+			heading := []string{"name", "key", "user", "createtime", "id"}
+			for _, key := range sshkeys {
+				fill := [][]string{
+					{
+						key.Properties.Name,
+						key.Properties.Sshkey[:10] + "..." + key.Properties.Sshkey[len(key.Properties.Sshkey)-30:],
+						key.Properties.UserUUID[:8],
+						key.Properties.CreateTime.String()[:19],
+						key.Properties.ObjectUUID,
+					},
+				}
+				sshkeyinfo = append(sshkeyinfo, fill...)
+			}
+			if idFlag {
+				rowsToDisplay = len(heading)
+			}
+			render.Table(out, heading[:rowsToDisplay], sshkeyinfo)
+		} else {
+			render.AsJSON(out, sshkeys)
+		}
+		fmt.Print(out)
+	},
+}
+var addCmd, removeCmd = &cobra.Command{
+	Use:   "add",
+	Short: "add ssh-key",
+	Long:  `Add ssh-key via file`,
+	Args:  cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		if nameFlag && fileFlag {
+			ctx := context.Background()
+			publicKey, err := ioutil.ReadFile(args[1])
+			if err != nil {
+				log.Error("Failed to read public-key from "+args[1], err)
+			}
+			key, err := client.CreateSshkey(ctx, gsclient.SshkeyCreateRequest{
+				Name:   args[0],
+				Sshkey: string(publicKey),
+			})
+			if err != nil {
+				log.Error("Create SSH-key has failed with error", err)
+				return
+			}
+			log.WithFields(log.Fields{
+				"sshkey_uuid": key.ObjectUUID,
+			}).Infof("SSH-key [%s] successfully created", args[0])
+		}
+	},
+}, &cobra.Command{
+	Use:   "remove",
+	Short: "remove ssh-key",
+	Long:  `Remove ssh-key via name or id`,
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if nameFlag {
+			ctx := context.Background()
+			sshkeys, err := client.GetSshkeyList(ctx)
+			if err != nil {
+				log.Error("Couldn't get SSH-keys:", err)
+				return
+			}
+			for _, key := range sshkeys {
+				if args[0] == key.Properties.ObjectUUID || args[0] == key.Properties.Name {
+					err := client.DeleteSshkey(ctx, key.Properties.ObjectUUID)
+					if err != nil {
+						log.Error("Delete SSH-key has failed with error", err)
+						return
+					}
+					log.Infof("SSH-key [%s] successfully removed", args[0])
+				}
+			}
+		}
+	},
+}
+
+func init() {
+	sshKeyCmd.AddCommand(addCmd, removeCmd)
+	sshKeyCmd.PersistentFlags().BoolVarP(&nameFlag, "name", "n", false, "Set ssh-key name")
+	sshKeyCmd.PersistentFlags().BoolVarP(&fileFlag, "file", "f", false, "Read ssh-key from file")
+	rootCmd.AddCommand(sshKeyCmd)
+}

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/gridscale/gscloud/render"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -19,7 +20,8 @@ var storageCmd = &cobra.Command{
 		out := new(bytes.Buffer)
 		storages, err := client.GetStorageList(ctx)
 		if err != nil {
-			panic(err)
+			log.Error("Couldn't get Storageinfo", err)
+			return
 		}
 		var storage [][]string
 		if !jsonFlag {


### PR DESCRIPTION
### Notes:
- Easy add your keys via file and give it an alias/name
- To remove a key, all you need is it's ID or NAME
- Using logrus instead of panic now for sshKeyCmd, serverCmd, storageCmd and networkCmd

### Examples:
$ ./gscloud ssh-key
$ ./gscloud ssh-key --id
$ ./gscloud ssh-key add --name <name/alias> --file <path/to/file>
$ ./gscloud ssh-key remove --name <[alias]or[uuid]>
```
Fixes https://github.com/gridscale/gscloud/issues/30