### PR TITLE
Quiet flag, prints ID column without heading

### DIFF
--- a/cmd/network.go
+++ b/cmd/network.go
@@ -39,9 +39,15 @@ var networkCmd = &cobra.Command{
 
 			}
 			if idFlag {
-				rowsToDisplay = len(heading)
+				upToColumn = len(heading)
 			}
-			render.Table(out, heading[:rowsToDisplay], networkinfos)
+			render.Table(out, heading[:upToColumn], networkinfos)
+			if quietFlag {
+				for _, info := range networkinfos {
+					fmt.Println(info[4])
+				}
+				return
+			}
 
 		} else {
 			render.AsJSON(out, networks)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,12 +10,13 @@ import (
 )
 
 var (
-	cfgFile       string
-	account       string
-	client        *gsclient.Client
-	jsonFlag      bool
-	idFlag        bool
-	rowsToDisplay = 4
+	cfgFile    string
+	account    string
+	client     *gsclient.Client
+	jsonFlag   bool
+	idFlag     bool
+	quietFlag  bool
+	upToColumn = 4
 )
 
 const (
@@ -51,6 +52,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&account, "account", "", "the account used, 'default' if none given")
 	rootCmd.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "Print JSON to stdout instead of a table")
 	rootCmd.PersistentFlags().BoolVarP(&idFlag, "id", "i", false, "Include ID column")
+	rootCmd.PersistentFlags().BoolVarP(&quietFlag, "quiet", "q", false, "Print ID column only")
 
 	rootCmd.AddCommand(kubernetesCmd)
 	kubernetesCmd.AddCommand(clusterCmd)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -45,9 +45,15 @@ var serverCmd = &cobra.Command{
 				serverinfos = append(serverinfos, fill...)
 			}
 			if idFlag {
-				rowsToDisplay = len(heading)
+				upToColumn = len(heading)
 			}
-			render.Table(out, heading[:rowsToDisplay], serverinfos)
+			if quietFlag {
+				for _, info := range serverinfos {
+					fmt.Println(info[4])
+				}
+				return
+			}
+			render.Table(out, heading[:upToColumn], serverinfos)
 		} else {
 			render.AsJSON(out, servers)
 		}

--- a/cmd/sshKey.go
+++ b/cmd/sshKey.go
@@ -42,9 +42,15 @@ var sshKeyCmd = &cobra.Command{
 				sshkeyinfo = append(sshkeyinfo, fill...)
 			}
 			if idFlag {
-				rowsToDisplay = len(heading)
+				upToColumn = len(heading)
 			}
-			render.Table(out, heading[:rowsToDisplay], sshkeyinfo)
+			if quietFlag {
+				for _, info := range sshkeyinfo {
+					fmt.Println(info[4])
+				}
+				return
+			}
+			render.Table(out, heading[:upToColumn], sshkeyinfo)
 		} else {
 			render.AsJSON(out, sshkeys)
 		}

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -23,7 +23,7 @@ var storageCmd = &cobra.Command{
 			log.Error("Couldn't get Storageinfo", err)
 			return
 		}
-		var storage [][]string
+		var storageinfo [][]string
 		if !jsonFlag {
 			heading := []string{"name", "capacity", "changetime", "status", "id"}
 			for _, stor := range storages {
@@ -36,12 +36,18 @@ var storageCmd = &cobra.Command{
 						stor.Properties.ObjectUUID,
 					},
 				}
-				storage = append(storage, fill...)
+				storageinfo = append(storageinfo, fill...)
 			}
 			if idFlag {
-				rowsToDisplay = len(heading)
+				upToColumn = len(heading)
 			}
-			render.Table(out, heading[:rowsToDisplay], storage)
+			if quietFlag {
+				for _, info := range storageinfo {
+					fmt.Println(info[4])
+				}
+				return
+			}
+			render.Table(out, heading[:upToColumn], storageinfo)
 
 		} else {
 			render.AsJSON(out, storages)


### PR DESCRIPTION
```
$ gscloud server --quiet
$ gscloud storage --quiet
$ gscloud network --quiet
$ gscloud ssh-key --quiet
```
Fixes https://github.com/gridscale/gscloud/issues/33
See also, refactor: rowsToDisplay -> upToColumn