### PR TITLE
Autocompletion for bash and zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ Flags:
 
 Use "gscloud [command] --help" for more information about a command.
 ```
+## Example to add Tab-Completion
+zsh
+```
+$ ./gscloud completion zsh >> ~/.zshrc
+```
+bash
+```
+$ ./gscloud completion bash >> ~/.bash_profile
+```
+> Note: You need to uncomment compdef to make it: work</br>
+`#compdef _gscloud gscloud`
 
 ## Example Configuration
 

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -7,8 +7,12 @@ import (
 
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
-	Use:                   "completion [bash|zsh]",
-	Short:                 "Generate completion script",
+	Use:   "completion [bash|zsh]",
+	Short: "Generate completion script",
+	Long: `Example to append a profile:
+$ ./gscloud completion zsh >> ~/.zshrc
+NOTE: You need to uncomment the first line: 
+#compdef _gscloud gscloud`,
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"bash", "zsh"},
 	Args:                  cobra.ExactValidArgs(1),

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var (
+	completionNoDesc bool
+	testFlag         string
+)
+
+// completionCmd represents the completion command
+var completionCmd = &cobra.Command{
+	Use:                   "completion [bash|zsh]",
+	Short:                 "Generate completion script",
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh"},
+	Args:                  cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+			break
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+			break
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -5,11 +5,6 @@ import (
 	"os"
 )
 
-var (
-	completionNoDesc bool
-	testFlag         string
-)
-
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
 	Use:                   "completion [bash|zsh]",


### PR DESCRIPTION
### $./gscloud completion [bash|zsh]

Example:
```
$ ./gscloud completion zsh >> ~/.zshrc
$ ./gscloud completion bash >> ~/.bash_profile
```
Fixes GD-2683