### PR TITLE
Make ls a proper command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 FEATURES:
 
-* We added `gscloud {server,storage,network}` commands.
+* We added `gscloud {server,storage,network,ssh-key}` commands.
 
 ## v0.2.0-beta (March 11, 2020)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Available Commands:
 
 Flags:
       --account string   Specify the account used; 'default' if none given
-      --config string    Specify a configuration file; default /home/bk/.config/gscloud/config.yaml
+      --config string    Specify a configuration file; default ~/.config/gscloud/config.yaml
   -h, --help             Print usage
   -j, --json             Print JSON to stdout instead of a table
   -q, --quiet            Print only IDs of objects

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# gscloud: The Command Line Interface for the gridscale cloud
+# gscloud: CLI for the gridscale cloud
 
 [![Build Status](https://travis-ci.com/gridscale/gscloud.svg?branch=develop)](https://travis-ci.com/gridscale/gscloud)
 
-## Supported Services
-
-    - kubernetes
-
 ## Overview
 
+gscloud lets you manage objects on [gridscale.io](https://my.gridscale.io) via shell.
+
+Note: this tool is still in the making and beta quality. Feel free to try it out. Feedback very welcome.
+
 ```txt
-gscloud --help
-gscloud is the command line interface for the gridscale cloud.
+$ gscloud --help
+gscloud is the CLI for the gridscale cloud.
 
 Usage:
   gscloud [command]
@@ -19,11 +19,18 @@ Available Commands:
   help        Help about any command
   kubernetes  Operate managed Kubernetes clusters
   make-config Create a new configuration file
+  network     Operations on networks
+  server      Operations on servers
+  ssh-key     Operations on SSH keys
+  storage     Operations on storages
+  version     Print the version
 
 Flags:
-      --account string   the account used, 'default' if none given
-      --config string    configuration file, default /home/bk/.config/gscloud/config.yaml
-  -h, --help             help for gscloud
+      --account string   Specify the account used; 'default' if none given
+      --config string    Specify a configuration file; default /home/bk/.config/gscloud/config.yaml
+  -h, --help             Print usage
+  -j, --json             Print JSON to stdout instead of a table
+  -q, --quiet            Print only IDs of objects
 
 Use "gscloud [command] --help" for more information about a command.
 ```

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -25,8 +25,7 @@ func produceNetworkCmdRunFunc(o networkOperator) cmdRunFunc {
 		out := new(bytes.Buffer)
 		networks, err := o.GetNetworkList(ctx)
 		if err != nil {
-			log.Error("Couldn't get Networkinfo", err)
-			return
+			log.Fatalf("Couldn't get network list: %s", err)
 		}
 		var networkinfos [][]string
 		if !jsonFlag {
@@ -62,9 +61,18 @@ func produceNetworkCmdRunFunc(o networkOperator) cmdRunFunc {
 func initNetworkCmd() {
 	var networkCmd = &cobra.Command{
 		Use:   "network",
-		Short: "Print network list",
-		Long:  `Print all networks information`,
-		Run:   produceNetworkCmdRunFunc(client),
+		Short: "Operations on networks",
+		Long:  `List, create, or remove networks.`,
 	}
+
+	var networkLsCmd = &cobra.Command{
+		Use:     "ls [flags]",
+		Aliases: []string{"list"},
+		Short:   "List networks",
+		Long:    `List network objects.`,
+		Run:     produceNetworkCmdRunFunc(client),
+	}
+
+	networkCmd.AddCommand(networkLsCmd)
 	rootCmd.AddCommand(networkCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,8 +25,8 @@ const (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "gscloud",
-	Short: "is the command line interface for the gridscale cloud.",
-	Long:  "gscloud is the command line interface for the gridscale cloud.",
+	Short: "is the CLI for the gridscale cloud.",
+	Long:  "gscloud is the CLI for the gridscale cloud.",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -43,10 +43,11 @@ func init() {
 		initConfig()
 		initClient()
 	}
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", fmt.Sprintf("configuration file, default %s", cliConfigPath()))
-	rootCmd.PersistentFlags().StringVar(&account, "account", "", "the account used, 'default' if none given")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", fmt.Sprintf("Specify a configuration file; default %s", cliConfigPath()))
+	rootCmd.PersistentFlags().StringVar(&account, "account", "", "Specify the account used; 'default' if none given")
 	rootCmd.PersistentFlags().BoolVarP(&jsonFlag, "json", "j", false, "Print JSON to stdout instead of a table")
-	rootCmd.PersistentFlags().BoolVarP(&quietFlag, "quiet", "q", false, "Print ID column only")
+	rootCmd.PersistentFlags().BoolVarP(&quietFlag, "quiet", "q", false, "Print only IDs of objects")
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
 
 	initMakeConfCmd()
 	initK8SCmd()

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -26,8 +26,7 @@ func produceStorageCmdRunFunc(o storageOperator) cmdRunFunc {
 		out := new(bytes.Buffer)
 		storages, err := o.GetStorageList(ctx)
 		if err != nil {
-			log.Error("Couldn't get Storageinfo", err)
-			return
+			log.Fatalf("Couldn't get storage list: %s", err)
 		}
 		var storageinfo [][]string
 		if !jsonFlag {
@@ -64,9 +63,19 @@ func produceStorageCmdRunFunc(o storageOperator) cmdRunFunc {
 func initStorageCmd() {
 	var storageCmd = &cobra.Command{
 		Use:   "storage",
-		Short: "Print storage list",
-		Long:  `Print all storage information`,
+		Short: "Operations on storages",
+		Long:  `List, create, or remove storages.`,
 		Run:   produceStorageCmdRunFunc(client),
 	}
+
+	var storageLsCmd = &cobra.Command{
+		Use:     "ls [flags]",
+		Aliases: []string{"list"},
+		Short:   "List storages",
+		Long:    `List storage objects.`,
+		Run:     produceStorageCmdRunFunc(client),
+	}
+
+	storageCmd.AddCommand(storageLsCmd)
 	rootCmd.AddCommand(storageCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,7 +20,7 @@ func initVersionCmd() {
 	var versionCmd = &cobra.Command{
 		Use:   "version",
 		Short: "Print the version",
-		Long:  `Display gscloud version information.`,
+		Long:  `Print version information.`,
 		Run:   versionCmdRun,
 	}
 	rootCmd.AddCommand(versionCmd)


### PR DESCRIPTION
This PR contains following changes:

- Make sure that `ls` is always a sub-command of {server,storage,network,ssh-key}`.
- Clearly distinct between flag and argument
- Properly handle errors
- Always return non-zero exit code on error
- Also make sure that README and help texts are consistent and up-to-date