### PR TITLE
Tab-Completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Available Commands:
   ssh-key     Operations on SSH keys
   storage     Operations on storages
   version     Print the version
+  completion  Generate shell Tab-Completion
 
 Flags:
       --account string   Specify the account used; 'default' if none given
@@ -86,4 +87,18 @@ users:
         - "exec-credential"
         - "--cluster"
         - "9489f3a7-c8f8-4b38-bc9b-aa472a1c0d2a"
+```
+## Example add Tab-Completion
+
+Uncomment compdef, otherwise it won't work.
+
+`#compdef _gscloud gscloud`
+
+zsh
+```
+$ ./gscloud completion zsh >> ~/.zshrc
+```
+bash
+```
+$ ./gscloud completion bash >> ~/.bash_profile
 ```

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// completionCmd represents the completion command
+var completionCmd = &cobra.Command{
+	Use:                   "completion [bash|zsh]",
+	Short:                 "Generate completion script",
+	Long:                  `Generate Tab-Completion script for bash or zsh shell`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh"},
+	Args:                  cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+			break
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+			break
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}


### PR DESCRIPTION
- Add completion for bash and zsh
- Update README

Example:
```
$./gscloud server TAB TAB

ls   -- List server

off  -- Turn server off

on   -- Turn server on
```

Resolves https://github.com/gridscale/gscloud/pull/40
Fixes https://github.com/gridscale/gscloud/pull/46 GD-2683