### PR TITLE
Show correct config path in --help for make-config

### DIFF
--- a/cmd/makeConfig.go
+++ b/cmd/makeConfig.go
@@ -40,7 +40,7 @@ stdout.
 Examples:
 
 Create a new configuration file at the default configuration path
-(%s/config.yaml):
+(%s):
 
 	gscloud make-config
 


### PR DESCRIPTION
Currently the output of ``gscloud --help make-config`` looks like this for me:
```
Create a new and possibly almost empty configuration file overwriting an
existing one if it exists. Prints the path to the newly created file to
stdout.

Examples:

Create a new configuration file at the default configuration path
(/Users/Wouter/Library/Application Support/gscloud/config.yaml/config.yaml):

	gscloud make-config

Create a new configuration file at a specified path:

	gscloud --config ~/myconfig.yaml make-config

Usage:
  gscloud make-config [flags]

Global Flags:
      --account string   Specify the account used; 'default' if none given
      --config string    Specify a configuration file; default /Users/Wouter/Library/Application Support/gscloud/config.yaml
  -h, --help             Print usage
  -j, --json             Print JSON to stdout instead of a table
  -q, --quiet            Print only IDs of objects
```
There is an error in this part:
```
(/Users/Wouter/Library/Application Support/gscloud/config.yaml/config.yaml):
```
Since the cliConfigPath function already returns the full path, ``/config.yaml`` doesn't need to be added after it.