### PR TITLE
Allow using help if there is no config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,7 +103,7 @@ func initClient() {
 // command line again.
 func commandWithoutConfig(cmdLine []string) bool {
 	var noConfigNeeded = []string{
-		"make-config", "version",
+		"make-config", "version", "help",
 	}
 	for _, cmd := range noConfigNeeded {
 		if contains(cmdLine, cmd) {


### PR DESCRIPTION
Help not being usable when there is no configuration file makes it a bit harder to figure out how to use the tool. You just get:
```
open /Users/Wouter/Library/Application Support/gscloud/config.yaml: no such file or directory
```
This does still need to be tested.