### PR TITLE
gscloud manpages

### DIFF
--- a/cmd/manpage.go
+++ b/cmd/manpage.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+	"log"
+)
+
+var manpagePath string
+
+// Manpage action enum
+const (
+	manpageCreateAction = iota
+)
+
+// produceManpageCmdRunFunc takes an instance of a struct that implements `manpageOperator`
+// returns a `cmdRunFunc`
+func produceManpageCmdRunFunc(action int) cmdRunFunc {
+	switch action {
+	case manpageCreateAction:
+		return func(cmd *cobra.Command, args []string) {
+
+			header := &doc.GenManHeader{
+				Title:   "GSCLOUD",
+				Section: "1",
+				Source:  "Copyright (c) 2020 gridscale GmbH",
+			}
+			fmt.Print(manpagePath)
+			err := doc.GenManTree(rootCmd, header, manpagePath)
+			if err != nil {
+				log.Fatalf("Couldn't create Manpage: %s", err)
+			}
+		}
+	default:
+	}
+	return nil
+}
+
+func initManpageCmd() {
+	var manpageCreateCmd = &cobra.Command{
+		Use:     "manpage [flags]",
+		Short:   "Add Manpage",
+		Long:    `Create manpage in given path.`,
+		Example: `./gscloud manpage --path "/path/to/your/manpages`,
+		Run:     produceManpageCmdRunFunc(manpageCreateAction),
+	}
+	manpageCreateCmd.PersistentFlags().StringVarP(&manpagePath, "path", "p", "", "Export Manpage to given path")
+
+	rootCmd.AddCommand(manpageCreateCmd)
+}

--- a/cmd/manpage.go
+++ b/cmd/manpage.go
@@ -7,8 +7,6 @@ import (
 	"log"
 )
 
-var manpagePath string
-
 // Manpage action enum
 const (
 	manpageCreateAction = iota
@@ -20,17 +18,16 @@ func produceManpageCmdRunFunc(action int) cmdRunFunc {
 	switch action {
 	case manpageCreateAction:
 		return func(cmd *cobra.Command, args []string) {
-
 			header := &doc.GenManHeader{
 				Title:   "GSCLOUD",
 				Section: "1",
 				Source:  "Copyright (c) 2020 gridscale GmbH",
 			}
-			fmt.Print(manpagePath)
-			err := doc.GenManTree(rootCmd, header, manpagePath)
+			err := doc.GenManTree(rootCmd, header, args[0])
 			if err != nil {
 				log.Fatalf("Couldn't create Manpage: %s", err)
 			}
+			fmt.Println("Manpages created:", args[0])
 		}
 	default:
 	}
@@ -42,10 +39,8 @@ func initManpageCmd() {
 		Use:     "manpage [flags]",
 		Short:   "Add Manpage",
 		Long:    `Create manpage in given path.`,
-		Example: `./gscloud manpage --path "/path/to/your/manpages`,
+		Example: `./gscloud manpage /path/to/manpages`,
 		Run:     produceManpageCmdRunFunc(manpageCreateAction),
 	}
-	manpageCreateCmd.PersistentFlags().StringVarP(&manpagePath, "path", "p", "", "Export Manpage to given path")
-
 	rootCmd.AddCommand(manpageCreateCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,9 +24,10 @@ const (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "gscloud",
-	Short: "is the CLI for the gridscale cloud.",
-	Long:  "gscloud is the CLI for the gridscale cloud.",
+	Use:               "gscloud",
+	Short:             "is the CLI for the gridscale cloud.",
+	Long:              "gscloud is the CLI for the gridscale cloud.",
+	DisableAutoGenTag: true,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -56,6 +57,7 @@ func init() {
 	initSSHKeyCmd()
 	initServerCmd()
 	initNetworkCmd()
+	initManpageCmd()
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
- Add manpage command
- Change some strings
- Remove path flag
- Add first argument instead

Example:
`$ ./gscloud manpage /usr/share/man`

Fixes GD-2684