### PR TITLE
Update server / set new values

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -189,12 +189,13 @@ var serverSetCmd = &cobra.Command{
 			gsclient.ServerUpdateRequest{
 				Cores:  cores,
 				Memory: memory,
-				Name: serverName,
+				Name:   serverName,
 			})
 		if err != nil {
 			log.Fatalf("Update of server: %s failed: %s", uServer.ObjectUUID, err)
 		}
 		fmt.Println("Server updated:", uServer.ObjectUUID)
+	},
 }
 
 func init() {
@@ -212,6 +213,6 @@ func init() {
 	serverSetCmd.PersistentFlags().IntVar(&cores, "cores", 1, "No. of cores")
 	serverSetCmd.PersistentFlags().StringVar(&serverName, "name", "", "Name of the server")
 
-	serverCmd.AddCommand(serverLsCmd, serverOnCmd, serverOffCmd, serverRmCmd, serverCreateCmd,serverSetCmd)
+	serverCmd.AddCommand(serverLsCmd, serverOnCmd, serverOffCmd, serverRmCmd, serverCreateCmd, serverSetCmd)
 	rootCmd.AddCommand(serverCmd)
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -174,6 +174,29 @@ var serverCreateCmd = &cobra.Command{
 	},
 }
 
+var serverSetCmd = &cobra.Command{
+	Use:     "set [ID] [flags]",
+	Example: `./gscloud server set ID --cores N`,
+	Short:   "Update server",
+	Long:    `Update values of an existing server.`,
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		serverOp := rt.ServerOperator()
+		ctx := context.Background()
+		uServer, err := serverOp.SetServer(
+			ctx,
+			args[0],
+			gsclient.ServerUpdateRequest{
+				Cores:  cores,
+				Memory: memory,
+				Name: serverName,
+			})
+		if err != nil {
+			log.Fatalf("Update of server: %s failed: %s", uServer.ObjectUUID, err)
+		}
+		fmt.Println("Server updated:", uServer.ObjectUUID)
+}
+
 func init() {
 	serverOffCmd.PersistentFlags().BoolVarP(&forceShutdown, "force", "f", false, "Force shutdown (no ACPI)")
 
@@ -185,6 +208,10 @@ func init() {
 	serverCreateCmd.PersistentFlags().StringVar(&hostName, "hostname", "", "Hostname")
 	serverCreateCmd.PersistentFlags().StringVar(&plainPassword, "password", "", "Plain-text password")
 
-	serverCmd.AddCommand(serverLsCmd, serverOnCmd, serverOffCmd, serverRmCmd, serverCreateCmd)
+	serverSetCmd.PersistentFlags().IntVar(&memory, "mem", 1, "Memory (GB)")
+	serverSetCmd.PersistentFlags().IntVar(&cores, "cores", 1, "No. of cores")
+	serverSetCmd.PersistentFlags().StringVar(&serverName, "name", "", "Name of the server")
+
+	serverCmd.AddCommand(serverLsCmd, serverOnCmd, serverOffCmd, serverRmCmd, serverCreateCmd,serverSetCmd)
 	rootCmd.AddCommand(serverCmd)
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -183,7 +183,7 @@ var serverSetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		serverOp := rt.ServerOperator()
 		ctx := context.Background()
-		uServer, err := serverOp.SetServer(
+		err := serverOp.UpdateServer(
 			ctx,
 			args[0],
 			gsclient.ServerUpdateRequest{
@@ -192,9 +192,8 @@ var serverSetCmd = &cobra.Command{
 				Name:   serverName,
 			})
 		if err != nil {
-			log.Fatalf("Update of server: %s failed: %s", uServer.ObjectUUID, err)
+			log.Fatalf("Failed: %s", err)
 		}
-		fmt.Println("Server updated:", uServer.ObjectUUID)
 	},
 }
 

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -48,6 +48,11 @@ func (o mockServerOp) CreateServerStorage(ctx context.Context, id string, body g
 	return nil
 }
 
+func (o mockServerOp) UpdateServer(ctx context.Context, id string, body gsclient.ServerUpdateRequest) error {
+	return nil
+
+}
+
 func Test_ServerCommmandDelete(t *testing.T) {
 	r, w, _ := os.Pipe()
 	rt, _ = runtime.NewTestRuntime()

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -52,7 +52,7 @@ type ServerOperator interface {
 	GetTemplateByName(ctx context.Context, name string) (gsclient.Template, error)
 	CreateStorage(ctx context.Context, body gsclient.StorageCreateRequest) (gsclient.CreateResponse, error)
 	CreateServerStorage(ctx context.Context, id string, body gsclient.ServerStorageRelationCreateRequest) error
-	SetServer(ctx context.Context, id string, body gsclient.ServerUpdateRequest) error
+	UpdateServer(ctx context.Context, id string, body gsclient.ServerUpdateRequest) error
 }
 
 // NetworkOperator interface that amalgamates all operations regarding network objects.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -52,6 +52,7 @@ type ServerOperator interface {
 	GetTemplateByName(ctx context.Context, name string) (gsclient.Template, error)
 	CreateStorage(ctx context.Context, body gsclient.StorageCreateRequest) (gsclient.CreateResponse, error)
 	CreateServerStorage(ctx context.Context, id string, body gsclient.ServerStorageRelationCreateRequest) error
+	SetServer(ctx context.Context, id string, body gsclient.ServerUpdateRequest) error
 }
 
 // NetworkOperator interface that amalgamates all operations regarding network objects.


### PR DESCRIPTION
- Remove unnecessary
- Implement UpdateServer Method
- Add Mock UpdateServer Method

No errors when changing values while the server is off. Works as expected.
Error when lower values while the server is switched on. Works as expected.
Received: `403, 'Forbidden - core hot-unplug not allowed.` 
Unfortunately I get the same error when I try to increase the values or change the name via gscloud when running as well.
It should be able to increase the memory and cores and change the name while the server is on, as it works in the web panel.
Could someone please take a look at it?