### PR TITLE
Use kubeconfig expire timestamp

### DIFF
--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -199,10 +199,10 @@ var execCredentialCmd = &cobra.Command{
 			if err := cacheKubeConfig(clusterID, execCredential); err != nil {
 				fmt.Fprintln(os.Stderr, err)
 			}
-		}
-		if execCredential == nil {
-			fmt.Println("Error: Could not retrieve kubeconfig from provider for account: ", account)
-			return
+
+			if execCredential == nil {
+				log.Fatalf("Could not retrieve kubeconfig from provider for account: %s", account)
+			}
 		}
 		execCredentialJSON, err := json.MarshalIndent(execCredential, "", "    ")
 		if err != nil {

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -184,6 +184,10 @@ var execCredentialCmd = &cobra.Command{
 				fmt.Println(err)
 			}
 
+			if expirationTime.IsZero() {
+				expirationTime = time.Now().Add(time.Hour)
+			}
+
 			execCredential = &clientauth.ExecCredential{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "ExecCredential",

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -233,28 +233,28 @@ func init() {
 	rootCmd.AddCommand(kubernetesCmd)
 }
 
-func fetchKubeConfigFromProvider(op runtime.KubernetesOperator, id string) (*kubeConfig, time.Time, error) {
+func fetchKubeConfigFromProvider(op runtime.KubernetesOperator, id string) (kubeConfig, time.Time, error) {
 	var kc kubeConfig
 	var expirationTime time.Time
 
 	if err := op.RenewK8sCredentials(context.Background(), id); err != nil {
-		return nil, time.Time{}, err
+		return kubeConfig{}, time.Time{}, err
 	}
 
 	platformService, err := op.GetPaaSService(context.Background(), id)
 	if err != nil {
-		return nil, time.Time{}, err
+		return kubeConfig{}, time.Time{}, err
 	}
 
 	if len(platformService.Properties.Credentials) != 0 {
 		err := yaml.Unmarshal([]byte(platformService.Properties.Credentials[0].KubeConfig), &kc)
 		if err != nil {
-			return nil, time.Time{}, err
+			return kubeConfig{}, time.Time{}, err
 		}
 		expirationTime = platformService.Properties.Credentials[0].ExpirationTime.Time
 	}
 
-	return &kc, expirationTime, nil
+	return kc, expirationTime, nil
 }
 
 func kubeConfigCachePath() string {

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -203,10 +203,6 @@ var execCredentialCmd = &cobra.Command{
 			if err := cacheKubeConfig(clusterID, execCredential); err != nil {
 				fmt.Fprintln(os.Stderr, err)
 			}
-
-			if execCredential == nil {
-				log.Fatalf("Could not retrieve kubeconfig from provider for account: %s", account)
-			}
 		}
 		execCredentialJSON, err := json.MarshalIndent(execCredential, "", "    ")
 		if err != nil {

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -192,7 +192,7 @@ var execCredentialCmd = &cobra.Command{
 				Status: &clientauth.ExecCredentialStatus{
 					ClientKeyData:         string(clientKeyData),
 					ClientCertificateData: string(clientCertificateData),
-					ExpirationTimestamp:   &metav1.Time{Time: *expirationTime},
+					ExpirationTimestamp:   &metav1.Time{Time: expirationTime},
 				},
 			}
 
@@ -229,28 +229,28 @@ func init() {
 	rootCmd.AddCommand(kubernetesCmd)
 }
 
-func fetchKubeConfigFromProvider(op runtime.KubernetesOperator, id string) (*kubeConfig, *time.Time, error) {
+func fetchKubeConfigFromProvider(op runtime.KubernetesOperator, id string) (*kubeConfig, time.Time, error) {
 	var kc kubeConfig
 	var expirationTime time.Time
 
 	if err := op.RenewK8sCredentials(context.Background(), id); err != nil {
-		return nil, nil, err
+		return nil, time.Time{}, err
 	}
 
 	platformService, err := op.GetPaaSService(context.Background(), id)
 	if err != nil {
-		return nil, nil, err
+		return nil, time.Time{}, err
 	}
 
 	if len(platformService.Properties.Credentials) != 0 {
 		err := yaml.Unmarshal([]byte(platformService.Properties.Credentials[0].KubeConfig), &kc)
 		if err != nil {
-			return nil, nil, err
+			return nil, time.Time{}, err
 		}
 		expirationTime = platformService.Properties.Credentials[0].ExpirationTime.Time
 	}
 
-	return &kc, &expirationTime, nil
+	return &kc, expirationTime, nil
 }
 
 func kubeConfigCachePath() string {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gridscale/gscloud
 go 1.13
 
 require (
-	github.com/gridscale/gsclient-go/v3 v3.1.0
+	github.com/gridscale/gsclient-go/v3 v3.2.0
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7 h1:6TSoaYExHper8PYsJu23GWVNOyYRCSnIFyxKgLSZ54w=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
-github.com/gridscale/gsclient-go/v3 v3.1.0 h1:TyJwIsv5aMUOcj09Y2DlcLfVvL6CDUWOy1HjuvExzLE=
-github.com/gridscale/gsclient-go/v3 v3.1.0/go.mod h1:hXZrJ+mDDcI2Xw+BhfrbYfiyA2xZNCDSOpB9XwEk19o=
+github.com/gridscale/gsclient-go/v3 v3.2.0 h1:cITTIlx/TtU58Lh70qVBYrxzEGSFZG31y1olDlG4jPA=
+github.com/gridscale/gsclient-go/v3 v3.2.0/go.mod h1:hXZrJ+mDDcI2Xw+BhfrbYfiyA2xZNCDSOpB9XwEk19o=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=


### PR DESCRIPTION
This PR addresses #67.

First, it updates gsclient-go version to 3.2 to have `expiration_time` in `paas_service` credentials and second, it  changes fetchKubeConfigFromProvider signature to also return the expiration time.

To verify, check that
    
        $ gscloud kubernetes cluster exec-credential --cluster=<ID>
    
saves the credential expiration time stamp from the PaaS definition in the cache directory.

