### PR TITLE
Use operator interfaces from gsclient-go

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -147,8 +147,11 @@ var serverCreateCmd = &cobra.Command{
 		fmt.Println("Server created:", cServer.ObjectUUID)
 
 		if template != "" {
-			template, _ := serverOp.GetTemplateByName(ctx, template)
-			cStorage, err := serverOp.CreateStorage(ctx, gsclient.StorageCreateRequest{
+			templateOp := rt.TemplateOperator()
+			template, _ := templateOp.GetTemplateByName(ctx, template)
+
+			storageOp := rt.StorageOperator()
+			cStorage, err := storageOp.CreateStorage(ctx, gsclient.StorageCreateRequest{
 				Name:        string(serverName),
 				Capacity:    storage,
 				StorageType: gsclient.DefaultStorageType,
@@ -159,7 +162,9 @@ var serverCreateCmd = &cobra.Command{
 					Hostname:     hostName,
 				},
 			})
-			serverOp.CreateServerStorage(
+
+			serverStorageOp := rt.ServerStorageRelationOperator()
+			serverStorageOp.CreateServerStorage(
 				ctx,
 				cServer.ObjectUUID,
 				gsclient.ServerStorageRelationCreateRequest{

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -23,33 +23,57 @@ type mockServerOp struct{}
 func (o mockServerOp) GetServerList(ctx context.Context) ([]gsclient.Server, error) {
 	return nil, nil
 }
+
 func (o mockServerOp) StartServer(ctx context.Context, id string) error {
 	return nil
 }
+
 func (o mockServerOp) StopServer(ctx context.Context, id string) error {
 	return nil
 }
+
 func (o mockServerOp) ShutdownServer(ctx context.Context, id string) error {
 	return nil
 }
+
 func (o mockServerOp) DeleteServer(ctx context.Context, id string) error {
 	return nil
 }
+
 func (o mockServerOp) CreateServer(ctx context.Context, body gsclient.ServerCreateRequest) (gsclient.ServerCreateResponse, error) {
 	return gsclient.ServerCreateResponse{}, nil
 }
-func (o mockServerOp) GetTemplateByName(ctx context.Context, name string) (gsclient.Template, error) {
-	return gsclient.Template{}, nil
-}
+
 func (o mockServerOp) CreateStorage(ctx context.Context, body gsclient.StorageCreateRequest) (gsclient.CreateResponse, error) {
 	return gsclient.CreateResponse{}, nil
-}
-func (o mockServerOp) CreateServerStorage(ctx context.Context, id string, body gsclient.ServerStorageRelationCreateRequest) error {
-	return nil
 }
 
 func (o mockServerOp) UpdateServer(ctx context.Context, id string, body gsclient.ServerUpdateRequest) error {
 	return nil
+}
+
+func (o mockServerOp) GetDeletedServers(ctx context.Context) ([]gsclient.Server, error) {
+	return []gsclient.Server{}, nil
+}
+
+func (o mockServerOp) GetServer(ctx context.Context, id string) (gsclient.Server, error) {
+	return gsclient.Server{}, nil
+}
+
+func (o mockServerOp) GetServerEventList(ctx context.Context, id string) ([]gsclient.Event, error) {
+	return []gsclient.Event{}, nil
+}
+
+func (o mockServerOp) GetServerMetricList(ctx context.Context, id string) ([]gsclient.ServerMetric, error) {
+	return []gsclient.ServerMetric{}, nil
+}
+
+func (o mockServerOp) GetServersByLocation(ctx context.Context, id string) ([]gsclient.Server, error) {
+	return []gsclient.Server{}, nil
+}
+
+func (o mockServerOp) IsServerOn(ctx context.Context, id string) (bool, error) {
+	return false, nil
 }
 
 func Test_ServerCommmandDelete(t *testing.T) {

--- a/cmd/storage_test.go
+++ b/cmd/storage_test.go
@@ -43,6 +43,34 @@ func (g mockClient) DeleteStorage(ctx context.Context, id string) error {
 	return nil
 }
 
+func (g mockClient) CloneStorage(ctx context.Context, id string) (gsclient.CreateResponse, error) {
+	return gsclient.CreateResponse{}, nil
+}
+
+func (g mockClient) CreateStorage(ctx context.Context, body gsclient.StorageCreateRequest) (gsclient.CreateResponse, error) {
+	return gsclient.CreateResponse{}, nil
+}
+
+func (g mockClient) GetDeletedStorages(ctx context.Context) ([]gsclient.Storage, error) {
+	return []gsclient.Storage{}, nil
+}
+
+func (g mockClient) GetStorage(ctx context.Context, id string) (gsclient.Storage, error) {
+	return gsclient.Storage{}, nil
+}
+
+func (g mockClient) GetStorageEventList(ctx context.Context, id string) ([]gsclient.Event, error) {
+	return []gsclient.Event{}, nil
+}
+
+func (g mockClient) GetStoragesByLocation(ctx context.Context, id string) ([]gsclient.Storage, error) {
+	return []gsclient.Storage{}, nil
+}
+
+func (g mockClient) UpdateStorage(ctx context.Context, id string, body gsclient.StorageUpdateRequest) error {
+	return nil
+}
+
 func Test_StorageListCmd(t *testing.T) {
 	marshalledMockStorage, _ := json.Marshal(mockStorageList)
 	type testCase struct {

--- a/runtime/account_test.go
+++ b/runtime/account_test.go
@@ -15,4 +15,3 @@ func Test_SelectAccount(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, rt.Account(), "test")
 }
-

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -16,49 +16,10 @@ type Runtime struct {
 	client      interface{}
 }
 
-// StorageOperator represents operations on storages.
-type StorageOperator interface {
-	DeleteStorage(ctx context.Context, id string) error
-	GetStorageList(ctx context.Context) ([]gsclient.Storage, error)
-}
-
-// TemplateOperator represents operations on templates.
-type TemplateOperator interface {
-	GetTemplateList(ctx context.Context) ([]gsclient.Template, error)
-	DeleteTemplate(ctx context.Context, id string) error
-}
-
 // KubernetesOperator amalgamates operations for Kubernetes PaaS.
 type KubernetesOperator interface {
 	RenewK8sCredentials(ctx context.Context, id string) error
 	GetPaaSService(ctx context.Context, id string) (gsclient.PaaSService, error)
-}
-
-// SSHKeyOperator is used for manipulating SSH keys.
-type SSHKeyOperator interface {
-	GetSshkeyList(ctx context.Context) ([]gsclient.Sshkey, error)
-	CreateSshkey(ctx context.Context, body gsclient.SshkeyCreateRequest) (gsclient.CreateResponse, error)
-	DeleteSshkey(ctx context.Context, id string) error
-}
-
-// ServerOperator contains all operations regarding server objects.
-type ServerOperator interface {
-	GetServerList(ctx context.Context) ([]gsclient.Server, error)
-	StartServer(ctx context.Context, id string) error
-	StopServer(ctx context.Context, id string) error
-	ShutdownServer(ctx context.Context, id string) error
-	DeleteServer(ctx context.Context, id string) error
-	CreateServer(ctx context.Context, body gsclient.ServerCreateRequest) (gsclient.ServerCreateResponse, error)
-	GetTemplateByName(ctx context.Context, name string) (gsclient.Template, error)
-	CreateStorage(ctx context.Context, body gsclient.StorageCreateRequest) (gsclient.CreateResponse, error)
-	CreateServerStorage(ctx context.Context, id string, body gsclient.ServerStorageRelationCreateRequest) error
-	UpdateServer(ctx context.Context, id string, body gsclient.ServerUpdateRequest) error
-}
-
-// NetworkOperator interface that amalgamates all operations regarding network objects.
-type NetworkOperator interface {
-	GetNetworkList(ctx context.Context) ([]gsclient.Network, error)
-	DeleteNetwork(ctx context.Context, id string) error
 }
 
 // Account is the current selected account.
@@ -67,15 +28,15 @@ func (r *Runtime) Account() string {
 }
 
 // StorageOperator return an operation to remove a storage.
-func (r *Runtime) StorageOperator() StorageOperator {
+func (r *Runtime) StorageOperator() gsclient.StorageOperator {
 	if UnderTest() {
-		return r.client.(StorageOperator)
+		return r.client.(gsclient.StorageOperator)
 	}
 	return r.client.(*gsclient.Client)
 }
 
 // SetStorageOperator set operation to delete storages.
-func (r *Runtime) SetStorageOperator(op StorageOperator) {
+func (r *Runtime) SetStorageOperator(op gsclient.StorageOperator) {
 	if !UnderTest() {
 		panic("unexpected use")
 	}
@@ -83,15 +44,15 @@ func (r *Runtime) SetStorageOperator(op StorageOperator) {
 }
 
 // TemplateOperator return an operation to remove a storage.
-func (r *Runtime) TemplateOperator() TemplateOperator {
+func (r *Runtime) TemplateOperator() gsclient.TemplateOperator {
 	if UnderTest() {
-		return r.client.(TemplateOperator)
+		return r.client.(gsclient.TemplateOperator)
 	}
 	return r.client.(*gsclient.Client)
 }
 
 // SetTemplateOperator set operation to delete storages.
-func (r *Runtime) SetTemplateOperator(op TemplateOperator) {
+func (r *Runtime) SetTemplateOperator(op gsclient.TemplateOperator) {
 	if !UnderTest() {
 		panic("unexpected use")
 	}
@@ -115,15 +76,15 @@ func (r *Runtime) SetKubernetesOperator(op KubernetesOperator) {
 }
 
 // SSHKeyOperator return operation to manipulate SSH keys.
-func (r *Runtime) SSHKeyOperator() SSHKeyOperator {
+func (r *Runtime) SSHKeyOperator() gsclient.SSHKeyOperator {
 	if UnderTest() {
-		return r.client.(SSHKeyOperator)
+		return r.client.(gsclient.SSHKeyOperator)
 	}
 	return r.client.(*gsclient.Client)
 }
 
 // SetSSHKeyOperator set operation to manipulate SSH keys.
-func (r *Runtime) SetSSHKeyOperator(op SSHKeyOperator) {
+func (r *Runtime) SetSSHKeyOperator(op gsclient.SSHKeyOperator) {
 	if !UnderTest() {
 		panic("unexpected use")
 	}
@@ -131,15 +92,15 @@ func (r *Runtime) SetSSHKeyOperator(op SSHKeyOperator) {
 }
 
 // ServerOperator return operation for server objects.
-func (r *Runtime) ServerOperator() ServerOperator {
+func (r *Runtime) ServerOperator() gsclient.ServerOperator {
 	if UnderTest() {
-		return r.client.(ServerOperator)
+		return r.client.(gsclient.ServerOperator)
 	}
 	return r.client.(*gsclient.Client)
 }
 
 // SetServerOperator set operation for server objects.
-func (r *Runtime) SetServerOperator(op ServerOperator) {
+func (r *Runtime) SetServerOperator(op gsclient.ServerOperator) {
 	if !UnderTest() {
 		panic("unexpected use")
 	}
@@ -147,15 +108,31 @@ func (r *Runtime) SetServerOperator(op ServerOperator) {
 }
 
 // NetworkOperator return operations for network objects.
-func (r *Runtime) NetworkOperator() NetworkOperator {
+func (r *Runtime) NetworkOperator() gsclient.NetworkOperator {
 	if UnderTest() {
-		return r.client.(NetworkOperator)
+		return r.client.(gsclient.NetworkOperator)
 	}
 	return r.client.(*gsclient.Client)
 }
 
 // SetNetworkOperator set operations to work on network objects.
-func (r *Runtime) SetNetworkOperator(op NetworkOperator) {
+func (r *Runtime) SetNetworkOperator(op gsclient.NetworkOperator) {
+	if !UnderTest() {
+		panic("unexpected use")
+	}
+	r.client = op
+}
+
+// ServerStorageRelationOperator return an operation to associate server objects with storages.
+func (r *Runtime) ServerStorageRelationOperator() gsclient.ServerStorageRelationOperator {
+	if UnderTest() {
+		return r.client.(gsclient.ServerStorageRelationOperator)
+	}
+	return r.client.(*gsclient.Client)
+}
+
+// SetServerStorageRelationOperator set operation to delete storages.
+func (r *Runtime) SetServerStorageRelationOperator(op gsclient.ServerStorageRelationOperator) {
 	if !UnderTest() {
 		panic("unexpected use")
 	}


### PR DESCRIPTION
Switches home-grown interfaces for those now in gsclient. Makes things actually not much less verbose, but hey, better type safe boilerplate than….