### PR TITLE
Add more unit tests for server commands

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -119,11 +119,9 @@ func Test_ServerCommmandDelete(t *testing.T) {
 		cmd(new(cobra.Command), []string{"rm", mockServer.Properties.ObjectUUID})
 		w.Close()
 		out, _ := ioutil.ReadAll(r)
+		assert.Equal(t, tc.expectedFatal, fatal)
 		if tc.isSuccessful {
-			assert.Equal(t, tc.expectedFatal, fatal)
 			assert.Equal(t, tc.expectedOutput, string(out))
-		} else {
-			assert.Equal(t, tc.expectedFatal, fatal)
 		}
 	}
 }
@@ -163,11 +161,9 @@ func Test_ServerCommmandLs(t *testing.T) {
 		cmd(new(cobra.Command), []string{"ls"})
 		w.Close()
 		out, _ := ioutil.ReadAll(r)
+		assert.Equal(t, tc.expectedFatal, fatal)
 		if tc.isSuccessful {
-			assert.Equal(t, tc.expectedFatal, fatal)
 			assert.Contains(t, string(out), tc.expectedPartOfOutput)
-		} else {
-			assert.Equal(t, tc.expectedFatal, fatal)
 		}
 	}
 }

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gridscale/gscloud/runtime"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 var mockServer = gsclient.Server{
@@ -18,7 +19,9 @@ var mockServer = gsclient.Server{
 	},
 }
 
-type mockServerOp struct{}
+type mockServerOp struct {
+	mock.Mock
+}
 
 func (o mockServerOp) GetServerList(ctx context.Context) ([]gsclient.Server, error) {
 	return nil, nil
@@ -33,11 +36,13 @@ func (o mockServerOp) StopServer(ctx context.Context, id string) error {
 }
 
 func (o mockServerOp) ShutdownServer(ctx context.Context, id string) error {
-	return nil
+	args := o.Called(id)
+	return args.Error(0)
 }
 
 func (o mockServerOp) DeleteServer(ctx context.Context, id string) error {
-	return nil
+	args := o.Called(id)
+	return args.Error(0)
 }
 
 func (o mockServerOp) CreateServer(ctx context.Context, body gsclient.ServerCreateRequest) (gsclient.ServerCreateResponse, error) {
@@ -80,6 +85,7 @@ func Test_ServerCommmandDelete(t *testing.T) {
 	r, w, _ := os.Pipe()
 	rt, _ = runtime.NewTestRuntime()
 	op := mockServerOp{}
+	op.On("DeleteServer", mock.Anything).Return(nil)
 	rt.SetServerOperator(op)
 	os.Stdout = w
 	cmd := serverRmCmd.Run

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -129,12 +129,20 @@ func Test_ServerCommmandDelete(t *testing.T) {
 func Test_ServerCommmandLs(t *testing.T) {
 	type testCase struct {
 		isSuccessful         bool
+		isJSONFormat         bool
 		expectedFatal        bool
 		expectedPartOfOutput string
 	}
 	testCases := []testCase{
 		{
 			isSuccessful:         true,
+			isJSONFormat:         false,
+			expectedFatal:        false,
+			expectedPartOfOutput: mockServer.Properties.ObjectUUID,
+		},
+		{
+			isSuccessful:         true,
+			isJSONFormat:         true,
 			expectedFatal:        false,
 			expectedPartOfOutput: mockServer.Properties.ObjectUUID,
 		},
@@ -147,6 +155,8 @@ func Test_ServerCommmandLs(t *testing.T) {
 	rt, _ = runtime.NewTestRuntime()
 	for _, tc := range testCases {
 		var fatal bool
+		rootFlags.json = tc.isJSONFormat
+
 		op := mockServerOp{}
 		if tc.isSuccessful {
 			op.On("GetServerList", mock.Anything).Return([]gsclient.Server{mockServer}, nil)
@@ -164,6 +174,10 @@ func Test_ServerCommmandLs(t *testing.T) {
 		assert.Equal(t, tc.expectedFatal, fatal)
 		if tc.isSuccessful {
 			assert.Contains(t, string(out), tc.expectedPartOfOutput)
+			if tc.isJSONFormat {
+				assert.Equal(t, "[{", string(out[:2]))
+				assert.Equal(t, "}]", string(out[len(out)-3:len(out)-1]))
+			}
 		}
 	}
 }

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -102,7 +102,6 @@ func Test_ServerCommmandDelete(t *testing.T) {
 			expectedOutput: "",
 		},
 	}
-	r, w, _ := os.Pipe()
 	rt, _ = runtime.NewTestRuntime()
 	for _, tc := range testCases {
 		var fatal bool
@@ -114,6 +113,7 @@ func Test_ServerCommmandDelete(t *testing.T) {
 			log.StandardLogger().ExitFunc = func(int) { fatal = true }
 		}
 		rt.SetServerOperator(op)
+		r, w, _ := os.Pipe()
 		os.Stdout = w
 		cmd := serverRmCmd.Run
 		cmd(new(cobra.Command), []string{"rm", mockServer.Properties.ObjectUUID})
@@ -144,7 +144,6 @@ func Test_ServerCommmandLs(t *testing.T) {
 			expectedPartOfOutput: "",
 		},
 	}
-	r, w, _ := os.Pipe()
 	rt, _ = runtime.NewTestRuntime()
 	for _, tc := range testCases {
 		var fatal bool
@@ -156,6 +155,7 @@ func Test_ServerCommmandLs(t *testing.T) {
 			log.StandardLogger().ExitFunc = func(int) { fatal = true }
 		}
 		rt.SetServerOperator(op)
+		r, w, _ := os.Pipe()
 		os.Stdout = w
 		cmd := serverLsCmd.Run
 		cmd(new(cobra.Command), []string{"ls"})


### PR DESCRIPTION
1. Add more unit tests and test cases for the existing tests of server cmd.
2. Use testify/mock to mock objects. This makes mocking a lot easier.
3. Move `...CmdRun` out of `cobra.Command`. So that the test coverage tool can detect these `...CmdRun` functions -> calculate the correct test cov.