### PR TITLE
Add info command

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -46,10 +46,10 @@ var infoCmd = &cobra.Command{
 					os.Exit(3)
 				}
 				fmt.Printf(
-					"Name: %s\nUserID: %s\nToken: %s\nURL: %s\n",
+					"Account: %s\nUserID: %s\nToken: %s\nURL: %s\n",
 					account.Name, account.UserID, account.Token, account.URL)
 				fmt.Printf(
-					"No. of servers: %d\nNo. of storages: %d\nNo. of ip addresses: %d\nNo. of ip PaaS services: %d\n",
+					"No. of servers: %d\nNo. of storages: %d\nNo. of ip addresses: %d\nNo. of platform services: %d\n",
 					len(servers), len(storages), len(ipAddrs), len(paasServices))
 			}
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -17,7 +17,25 @@ import (
 var infoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Print account summary",
-	Long:  `Print information about the current accounts.`,
+	Long: `Print information about the current account.
+
+# EXAMPLES
+
+Show summary for a given account:
+
+	$ gscloud --account=dev@example.com info
+	SETTING    VALUE
+	Account    dev@example.com
+	User ID    7ff8003b-55c5-45c5-bf0c-3746735a4f99
+	API token  <redacted>
+	URL        https://api.gridscale.io
+	Getting information about used resources…
+	OBJECT             COUNT
+	Platform services  0
+	Servers            18
+	Storages           24
+	IP addresses       2
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		type output struct {

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,12 +1,23 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"strconv"
 
+	"github.com/gridscale/gscloud/render"
 	"github.com/gridscale/gscloud/runtime"
 	"github.com/spf13/cobra"
 )
+
+type infoJSONOutput struct {
+	runtime.AccountEntry
+	ServerCount  int `json:"server_count"`
+	StorageCount int `json:"storage_count"`
+	IPAddrCount  int `json:"ip_address_count"`
+	PaaSCount    int `json:"paas_service_count"`
+}
 
 var infoCmd = &cobra.Command{
 	Use:   "info",
@@ -21,6 +32,25 @@ var infoCmd = &cobra.Command{
 			accountName := rt.Account()
 			// get info of the current account
 			if account.Name == accountName {
+				// Print auth info
+				if !rootFlags.json {
+					out := new(bytes.Buffer)
+					heading := []string{"Name", "UserID", "Token", "URL"}
+					fill := [][]string{
+						{
+							account.Name,
+							account.UserID,
+							account.Token,
+							account.URL,
+						},
+					}
+					var rows [][]string
+					rows = append(rows, fill...)
+					render.AsTable(out, heading, rows, renderOpts)
+					fmt.Print(out)
+					fmt.Printf("\nGetting infomation about available resources...\n\n\n")
+				}
+
 				// Get info about primitive resources
 				client := rt.Client()
 				servers, err := client.GetServerList(context.Background())
@@ -39,14 +69,32 @@ var infoCmd = &cobra.Command{
 				if err != nil {
 					return NewError(cmd, "Could not get PaaS services' information", err)
 				}
-				fmt.Printf(
-					"Account: %s\nUserID: %s\nToken: %s\nURL: %s\n",
-					account.Name, account.UserID, account.Token, account.URL)
-				fmt.Printf(
-					"No. of servers: %d\nNo. of storages: %d\nNo. of ip addresses: %d\nNo. of platform services: %d\n",
-					len(servers), len(storages), len(ipAddrs), len(paasServices))
+				out := new(bytes.Buffer)
+				if !rootFlags.json {
+					heading := []string{"No. of servers", "No. of storages", "No. of ip addresses", "No. of PaaS services"}
+					fill := [][]string{
+						{
+							strconv.Itoa(len(servers)),
+							strconv.Itoa(len(storages)),
+							strconv.Itoa(len(ipAddrs)),
+							strconv.Itoa(len(paasServices)),
+						},
+					}
+					var rows [][]string
+					rows = append(rows, fill...)
+					render.AsTable(out, heading, rows, renderOpts)
+				} else {
+					jsonOutput := infoJSONOutput{
+						AccountEntry: account,
+						ServerCount:  len(servers),
+						StorageCount: len(storages),
+						IPAddrCount:  len(ipAddrs),
+						PaaSCount:    len(paasServices),
+					}
+					render.AsJSON(out, jsonOutput)
+				}
+				fmt.Print(out)
 			}
-
 		}
 		return nil
 	},

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/gridscale/gscloud/runtime"
 	"github.com/spf13/cobra"
@@ -13,11 +12,10 @@ var infoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Print the info",
 	Long:  `Print information belongs to gscloud accounts.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		conf, err := runtime.ParseConfig()
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(3)
+			return NewError(cmd, "Could parse configuration", err)
 		}
 		for _, account := range conf.Accounts {
 			accountName := rt.Account()
@@ -27,23 +25,19 @@ var infoCmd = &cobra.Command{
 				client := rt.Client()
 				servers, err := client.GetServerList(context.Background())
 				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-					os.Exit(3)
+					return NewError(cmd, "Could not get servers' information", err)
 				}
 				storages, err := client.GetStorageList(context.Background())
 				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-					os.Exit(3)
+					return NewError(cmd, "Could not get storages' information", err)
 				}
 				ipAddrs, err := client.GetIPList(context.Background())
 				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-					os.Exit(3)
+					return NewError(cmd, "Could not get ip addresses' information", err)
 				}
 				paasServices, err := client.GetPaaSServiceList(context.Background())
 				if err != nil {
-					fmt.Fprintln(os.Stderr, err)
-					os.Exit(3)
+					return NewError(cmd, "Could not get PaaS services' information", err)
 				}
 				fmt.Printf(
 					"Account: %s\nUserID: %s\nToken: %s\nURL: %s\n",
@@ -66,7 +60,7 @@ func init() {
 		if cmd.Name() == "info" || (cmd.HasParent() && cmd.Parent().Name() == "info") {
 			cmd.Flags().MarkHidden("account")
 			cmd.Flags().MarkHidden("config")
-			cmd.Flags().MarkHidden("json")
+			// cmd.Flags().MarkHidden("json")
 			cmd.Flags().MarkHidden("quiet")
 		}
 		origHelpFunc(cmd, args)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/gridscale/gscloud/runtime"
+	"github.com/spf13/cobra"
+)
+
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Print the info",
+	Long:  `Print information belongs to gscloud accounts.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		conf, err := runtime.ParseConfig()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(3)
+		}
+		for _, account := range conf.Accounts {
+			accountName := rt.Account()
+			// get info of the current account
+			if account.Name == accountName {
+				// Get info about primitive resources
+				client := rt.Client()
+				servers, err := client.GetServerList(context.Background())
+				if err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(3)
+				}
+				storages, err := client.GetStorageList(context.Background())
+				if err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(3)
+				}
+				ipAddrs, err := client.GetIPList(context.Background())
+				if err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(3)
+				}
+				paasServices, err := client.GetPaaSServiceList(context.Background())
+				if err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(3)
+				}
+				fmt.Printf(
+					"Name: %s\nUserID: %s\nToken: %s\nURL: %s\n",
+					account.Name, account.UserID, account.Token, account.URL)
+				fmt.Printf(
+					"No. of servers: %d\nNo. of storages: %d\nNo. of ip addresses: %d\nNo. of ip PaaS services: %d\n",
+					len(servers), len(storages), len(ipAddrs), len(paasServices))
+			}
+
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(infoCmd)
+
+	// Hide some global persistent flags here that don't make sense on 'version'
+	origHelpFunc := versionCmd.HelpFunc()
+	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		if cmd.Name() == "info" || (cmd.HasParent() && cmd.Parent().Name() == "info") {
+			cmd.Flags().MarkHidden("account")
+			cmd.Flags().MarkHidden("config")
+			cmd.Flags().MarkHidden("json")
+			cmd.Flags().MarkHidden("quiet")
+		}
+		origHelpFunc(cmd, args)
+	})
+}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -35,7 +35,7 @@ var infoCmd = &cobra.Command{
 				// Print auth info
 				if !rootFlags.json {
 					out := new(bytes.Buffer)
-					heading := []string{"Name", "UserID", "Token", "URL"}
+					heading := []string{"Account", "UserID", "Token", "URL"}
 					fill := [][]string{
 						{
 							account.Name,
@@ -71,7 +71,7 @@ var infoCmd = &cobra.Command{
 				}
 				out := new(bytes.Buffer)
 				if !rootFlags.json {
-					heading := []string{"No. of servers", "No. of storages", "No. of ip addresses", "No. of PaaS services"}
+					heading := []string{"No. of servers", "No. of storages", "No. of ip addresses", "No. of platform services"}
 					fill := [][]string{
 						{
 							strconv.Itoa(len(servers)),

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -48,6 +48,7 @@ var infoCmd = &cobra.Command{
 			}
 
 		}
+		return nil
 	},
 }
 

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -7,10 +7,10 @@ import (
 
 // AccountEntry represents a single account in the config file.
 type AccountEntry struct {
-	Name   string `yaml:"name"`
-	UserID string `yaml:"userId"`
-	Token  string `yaml:"token"`
-	URL    string `yaml:"url"`
+	Name   string `yaml:"name" json:"name"`
+	UserID string `yaml:"userId" json:"userId"`
+	Token  string `yaml:"token" json:"token"`
+	URL    string `yaml:"url" json:"url"`
 }
 
 // Config are all configuration settings parsed from a configuration file.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -14,6 +14,7 @@ import (
 type Runtime struct {
 	accountName string
 	client      interface{}
+	config      Config
 }
 
 // KubernetesOperator amalgamates operations for Kubernetes PaaS.
@@ -46,6 +47,11 @@ func (r *Runtime) Account() string {
 // Client provides access to the API client.
 func (r *Runtime) Client() *gsclient.Client {
 	return r.client.(*gsclient.Client)
+}
+
+// Config allows access to configuration.
+func (r *Runtime) Config() *Config {
+	return &r.config
 }
 
 // ServerIPRelationOperator return an operation to remove a storage.
@@ -232,6 +238,7 @@ func NewRuntime(conf Config, accountName string) (*Runtime, error) {
 	rt := &Runtime{
 		accountName: ac.Name,
 		client:      client,
+		config:      conf,
 	}
 	return rt, nil
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -256,7 +256,12 @@ func CachePath() string {
 	return configdir.LocalCache("gscloud")
 }
 
+// newClient creates new gsclient from a given instance of AccountEntry
 func newClient(account AccountEntry) *gsclient.Client {
+	if account.URL == "" {
+		config := gsclient.DefaultConfiguration(account.UserID, account.Token)
+		return gsclient.NewClient(config)
+	}
 	config := gsclient.NewConfiguration(
 		account.URL,
 		account.UserID,


### PR DESCRIPTION
Add a gscloud info that quickly gives you a rough overview of the current working account.

- token.
- user ID.
- API URL used.
- Object counts of servers, storages, IP addresses, and PaaS services.