### PR TITLE
Add shell script to build source release files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
-PLATFORMS=windows linux darwin
-ARCHES=amd64
 VERSION=$$(git describe --tags)
 GIT_COMMIT=$$(git rev-list -1 HEAD)
-EXECUTABLE_NAME=gscloud_$(VERSION)
 
 default: build
 

--- a/release-src.sh
+++ b/release-src.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+REPO=https://github.com/gridscale/gscloud.git
+VERSION=`git describe --tags`
+GIT_COMMIT=`git rev-list -1 HEAD`
+
+CURDIR=`pwd`
+RELDIR=$(mktemp -d)
+
+cd $RELDIR
+
+git clone $REPO
+cd gscloud
+git checkout $1
+
+sed -e "s/VERSION=\$\$(git describe --tags)/VERSION=${VERSION}/g" -e "s/GIT_COMMIT=\$\$(git rev-list -1 HEAD)/GIT_COMMIT=${GIT_COMMIT}/g"  Makefile > Makefile.tmp
+mv Makefile.tmp Makefile
+
+rm -rf .git
+
+mkdir ${RELDIR}/gscloud_${VERSION}
+
+cp -R . ${RELDIR}/gscloud_${VERSION}
+
+cd ${RELDIR} && tar czfv gscloud_${VERSION}.tgz gscloud_${VERSION}/
+cd ${RELDIR} && zip -r gscloud_${VERSION}.zip gscloud_${VERSION}/
+
+cd ${CURDIR}
+mkdir -p release
+
+cp ${RELDIR}/gscloud_${VERSION}.tgz release/
+cp ${RELDIR}/gscloud_${VERSION}.zip release/
+
+rm -r ${RELDIR}
+

--- a/release-src.sh
+++ b/release-src.sh
@@ -1,5 +1,16 @@
 #!/bin/sh
 
+error() {
+	echo ""
+	echo "$1"
+	echo ""
+	exit 1
+}
+
+if [[ $# -eq 0 ]] ; then
+	error "Submit a valid git tag as an argument."
+fi
+
 REPO=https://github.com/gridscale/gscloud.git
 VERSION=`git describe --tags`
 GIT_COMMIT=`git rev-list -1 HEAD`
@@ -10,8 +21,17 @@ RELDIR=$(mktemp -d)
 cd $RELDIR
 
 git clone $REPO
+
+if [[ $? -ne 0 ]]; then
+	error "Error cloning repo"
+fi
+
 cd gscloud
 git checkout $1
+
+if [[ $? -ne 0 ]]; then
+	error "Error switching to supplied git tag"
+fi
 
 sed -e "s/VERSION=\$\$(git describe --tags)/VERSION=${VERSION}/g" -e "s/GIT_COMMIT=\$\$(git rev-list -1 HEAD)/GIT_COMMIT=${GIT_COMMIT}/g"  Makefile > Makefile.tmp
 mv Makefile.tmp Makefile


### PR DESCRIPTION
The current source release files that are built by the standard github version release process are missing infos in the Makefile:

---
VERSION=$$(git describe --tags)
GIT_COMMIT=$$(git rev-list -1 HEAD)
---

Will not work as those source tarballs/zip-files are no git checkouts. This shell script will create two files based upon the tag that is given on the commandline:

$ ./release-src.sh v0.10.0

will create a tarball and a zip-archive in release/ for the given tag.
