### PR TITLE
Return valid json when --json is given

### DIFF
--- a/cmd/isoImage.go
+++ b/cmd/isoImage.go
@@ -105,6 +105,10 @@ Create a Fedora CoreOS image:
 	   --source-url="https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/33.20201214.3.1/x86_64/fedora-coreos-33.20201214.3.1-live.x86_64.iso"
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		type output struct {
+			Image string `json:"image"`
+		}
+
 		imageOp := rt.ISOImageOperator()
 		ctx := context.Background()
 		image, err := imageOp.CreateISOImage(ctx, gsclient.ISOImageCreateRequest{
@@ -114,7 +118,11 @@ Create a Fedora CoreOS image:
 		if err != nil {
 			return NewError(cmd, "Creating image failed", err)
 		}
-		fmt.Println("Image created:", image.ObjectUUID)
+		if !rootFlags.json {
+			fmt.Println("Image created:", image.ObjectUUID)
+		} else {
+			render.AsJSON(os.Stdout, output{Image: image.ObjectUUID})
+		}
 		return nil
 	},
 }

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -85,6 +85,10 @@ Create a network:
 
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		type output struct {
+			Network string `json:"network"`
+		}
+
 		networkOp := rt.NetworkOperator()
 		ctx := context.Background()
 		network, err := networkOp.CreateNetwork(ctx, gsclient.NetworkCreateRequest{
@@ -94,7 +98,11 @@ Create a network:
 		if err != nil {
 			return NewError(cmd, "Could not create network", err)
 		}
-		fmt.Println("Network created:", network.ObjectUUID)
+		if !rootFlags.json {
+			fmt.Println("Network created:", network.ObjectUUID)
+		} else {
+			render.AsJSON(os.Stdout, output{Network: network.ObjectUUID})
+		}
 		return nil
 	},
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -276,6 +276,12 @@ To create a server without any storage just omit --with-template flag:
 	$ gscloud server create --name worker-2 --cores=1 --mem=1
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		type output struct {
+			Server   string `json:"server"`
+			Storage  string `json:"storage"`
+			Password string `json:"password"`
+		}
+
 		var templateID string
 
 		serverOp := rt.ServerOperator()
@@ -353,9 +359,22 @@ To create a server without any storage just omit --with-template flag:
 				return NewError(cmd, "Linking storage to server failed", err)
 			}
 			cleanupServer = false
-			fmt.Println("Server created:", server.ObjectUUID)
-			fmt.Println("Storage created:", storage.ObjectUUID)
-			fmt.Println("Password:", password)
+
+			if !rootFlags.json {
+				fmt.Println("Server created:", server.ObjectUUID)
+				fmt.Println("Storage created:", storage.ObjectUUID)
+				fmt.Println("Password:", password)
+			} else {
+				out := new(bytes.Buffer)
+
+				jsonOutput := output{
+					Server:   server.ObjectUUID,
+					Storage:  storage.ObjectUUID,
+					Password: password,
+				}
+				render.AsJSON(out, jsonOutput)
+				fmt.Println(out)
+			}
 		}
 
 		cleanupServer = false

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -365,15 +365,12 @@ To create a server without any storage just omit --with-template flag:
 				fmt.Println("Storage created:", storage.ObjectUUID)
 				fmt.Println("Password:", password)
 			} else {
-				out := new(bytes.Buffer)
-
 				jsonOutput := output{
 					Server:   server.ObjectUUID,
 					Storage:  storage.ObjectUUID,
 					Password: password,
 				}
-				render.AsJSON(out, jsonOutput)
-				fmt.Println(out)
+				render.AsJSON(os.Stdout, jsonOutput)
 			}
 		}
 


### PR DESCRIPTION
These commands would print the UUID of the object they created, but not in JSON even when --json was given. Fixes #95