### PR TITLE
Add env variable to control account (#138)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -151,8 +151,13 @@ func init() {
 	rootCmd.SilenceUsage = true
 	rootCmd.SilenceErrors = true
 
+	account, accountEnvPresent := os.LookupEnv("GSCLOUD_ACCOUNT")
+	if !accountEnvPresent {
+		account = "default"
+	}
+
 	rootCmd.PersistentFlags().StringVar(&rootFlags.configFile, "config", runtime.ConfigPathWithoutUser(), "Path to configuration file")
-	rootCmd.PersistentFlags().StringVarP(&rootFlags.account, "account", "", "default", "Specify the account used")
+	rootCmd.PersistentFlags().StringVarP(&rootFlags.account, "account", "", account, "Specify the account used")
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.json, "json", "j", false, "Print JSON to stdout instead of a table")
 	rootCmd.PersistentFlags().BoolVarP(&renderOpts.NoHeader, "noheading", "", false, "Do not print column headings")
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.quiet, "quiet", "q", false, "Print only object IDs")


### PR DESCRIPTION
If GSCLOUD_ACCOUNT is present, use its value instead of "default" when
no --account was given. --account has precedence over GSCLOUD_ACCOUNT,
allowing for a configuration with one default account and multiple
others in the config that aren't used often

Fixes #138