### PR TITLE
Read user id, API token and API URL from environment variables

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -131,7 +131,16 @@ Get the list of storages as JSON:
 
 GSCLOUD_ACCOUNT
 	Specify the account used. Gets overriden by --account option
-	  	
+
+GSCLOUD_USER_ID
+	Specify the user id used. Overrides the value in the config file
+
+GSCLOUD_API_TOKEN
+	Specify the API token used. Overrides the value in the config file
+
+GSCLOUD_API_URL
+	Specify the URL of the API. Overrides the value in the config file
+
 `, runtime.ConfigPathWithoutUser()),
 	DisableAutoGenTag: true,
 }


### PR DESCRIPTION
I didn't really know where to put this in the code, but this seems to be reasonable, as here it's already known which AccountEntry from conf.Accounts is actually used, so you can modify that one directly, on the downside however this introduces a maybe unclear effect to the function that the user might not expect

Fixes #139