### PR TITLE
Fix CommandWithoutConfig

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,4 +1,4 @@
-package runtime
+package cmd
 
 import (
 	"testing"

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -45,29 +45,3 @@ func ParseConfig() (*Config, error) {
 	}
 	return &conf, nil
 }
-
-// CommandWithoutConfig return true if current command does not need a config file.
-// Called from within a cobra initializer function. Unfortunately there is no
-// way of getting the current command from an cobra initializer so we scan the
-// command line again.
-func CommandWithoutConfig(cmdLine []string) bool {
-	var noConfigNeeded = []string{
-		"make-config", "version", "manpage", "completion",
-	}
-	for _, cmd := range noConfigNeeded {
-		if contains(cmdLine, cmd) {
-			return true
-		}
-	}
-	return false
-}
-
-// contains tests whether string e is in slice s.
-func contains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -216,7 +216,7 @@ func (r *Runtime) SetServerStorageRelationOperator(op gsclient.ServerStorageRela
 
 // NewRuntime creates a new runtime for a given account. Usually there should be
 // only one runtime instance in the program.
-func NewRuntime(conf Config, accountName string) (*Runtime, error) {
+func NewRuntime(conf Config, accountName string, commandWithoutConfig bool) (*Runtime, error) {
 	var ac AccountEntry
 	var accountIndex = -1
 
@@ -229,7 +229,7 @@ func NewRuntime(conf Config, accountName string) (*Runtime, error) {
 	}
 
 	if accountIndex == -1 {
-		if len(conf.Accounts) > 0 && !CommandWithoutConfig(os.Args) {
+		if len(conf.Accounts) > 0 && !commandWithoutConfig {
 			return nil, fmt.Errorf("account '%s' does not exist", accountName)
 		}
 	} else {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -64,7 +64,7 @@ func Test_NewRuntime(t *testing.T) {
 		oldEnviron := os.Environ()
 		resetEnv(test.Environment)
 
-		rt, err := NewRuntime(test.Configuration, test.AccountName)
+		rt, err := NewRuntime(test.Configuration, test.AccountName, false)
 
 		assert.Equal(t, test.ExpectedErrorIsNil, err == nil)
 		assert.Equal(t, test.ExpectedRuntimeIsNil, rt == nil)


### PR DESCRIPTION
Uses rootCmd.Find(os.Args[1:]). Fixes #147