### PR TITLE
Fix manpage crash (#150)

### DIFF
--- a/cmd/manpage.go
+++ b/cmd/manpage.go
@@ -39,6 +39,7 @@ This will overwrite any existing man-page created previously.
 		fmt.Printf("Written to %s\n", absPath)
 		return nil
 	},
+	Args: cobra.ExactValidArgs(1),
 }
 
 func init() {


### PR DESCRIPTION
Adds the requirement to specify exactly one argument when calling `gscloud manpage`

Fixes #150