### PR TITLE
Increase consistency of flags

### DIFF
--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -344,12 +344,12 @@ func init() {
 	ipAddCmd.PersistentFlags().BoolVarP(&ipFlags.v4, "v4", "4", false, "Add a new IPv4 address")
 	ipAddCmd.PersistentFlags().BoolVarP(&ipFlags.v6, "v6", "6", false, "Add a new IPv6 address")
 	ipAddCmd.PersistentFlags().StringVarP(&ipFlags.name, "name", "n", "", "Optional name of the IP address being created. Can be omitted")
-	ipAddCmd.PersistentFlags().BoolVarP(&ipFlags.failover, "failover", "", false, "Enable failover. If given, IP is no longer available for DHCP and cannot be assigned")
-	ipAddCmd.PersistentFlags().StringVarP(&ipFlags.reverseDNS, "reverse-dns", "", "", "Optional reverse DNS entry for the IP address")
+	ipAddCmd.PersistentFlags().BoolVar(&ipFlags.failover, "failover", false, "Enable failover. If given, IP is no longer available for DHCP and cannot be assigned")
+	ipAddCmd.PersistentFlags().StringVar(&ipFlags.reverseDNS, "reverse-dns", "", "Optional reverse DNS entry for the IP address")
 
 	ipSetCmd.PersistentFlags().StringVarP(&ipFlags.name, "name", "n", "", "Change name of the IP address")
-	ipSetCmd.PersistentFlags().BoolVarP(&ipFlags.failover, "failover", "", false, "Enable failover")
-	ipSetCmd.PersistentFlags().StringVarP(&ipFlags.reverseDNS, "reverse-dns", "", "", "Set reverse DNS entry")
+	ipSetCmd.PersistentFlags().BoolVar(&ipFlags.failover, "failover", false, "Enable failover")
+	ipSetCmd.PersistentFlags().StringVar(&ipFlags.reverseDNS, "reverse-dns", "", "Set reverse DNS entry")
 
 	ipAssignCmd.PersistentFlags().StringVarP(&ipFlags.targetID, "to", "t", "", "ID of target server or load balancer")
 	ipAssignCmd.MarkPersistentFlagRequired("to")

--- a/cmd/isoImage.go
+++ b/cmd/isoImage.go
@@ -128,7 +128,7 @@ Create a Fedora CoreOS image:
 }
 
 func init() {
-	isoImageCreateCmd.Flags().StringVar(&isoImageFlags.name, "name", "", "Name of the image")
+	isoImageCreateCmd.Flags().StringVarP(&isoImageFlags.name, "name", "n", "", "Name of the image")
 	isoImageCreateCmd.MarkFlagRequired("name")
 	isoImageCreateCmd.Flags().StringVar(&isoImageFlags.sourceURL, "source-url", "", "URL from where the image is downloaded")
 	isoImageCreateCmd.MarkFlagRequired("source-url")

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -126,7 +126,7 @@ var networkRmCmd = &cobra.Command{
 }
 
 func init() {
-	networkCreateCmd.Flags().StringVar(&networkFlags.networkName, "name", "", "Name of the network")
+	networkCreateCmd.Flags().StringVarP(&networkFlags.networkName, "name", "n", "", "Name of the network")
 
 	networkCmd.AddCommand(networkLsCmd, networkRmCmd, networkCreateCmd)
 	rootCmd.AddCommand(networkCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -172,11 +172,11 @@ func init() {
 	}
 
 	rootCmd.PersistentFlags().StringVar(&rootFlags.configFile, "config", runtime.ConfigPathWithoutUser(), "Path to configuration file")
-	rootCmd.PersistentFlags().StringVarP(&rootFlags.account, "account", "", account, "Specify the account used. Overrides GRIDSCALE_ACCOUNT environment variable")
+	rootCmd.PersistentFlags().StringVar(&rootFlags.account, "account", account, "Specify the account used. Overrides GRIDSCALE_ACCOUNT environment variable")
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.json, "json", "j", false, "Print JSON to stdout instead of a table")
-	rootCmd.PersistentFlags().BoolVarP(&renderOpts.NoHeader, "noheading", "", false, "Do not print column headings")
+	rootCmd.PersistentFlags().BoolVar(&renderOpts.NoHeader, "noheading", false, "Do not print column headings")
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.quiet, "quiet", "q", false, "Print only object IDs")
-	rootCmd.PersistentFlags().BoolVarP(&rootFlags.debug, "debug", "", false, "Debug mode")
+	rootCmd.PersistentFlags().BoolVar(&rootFlags.debug, "debug", false, "Debug mode")
 	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
 }
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -501,7 +501,7 @@ func init() {
 	serverCreateCmd.Flags().IntVar(&serverFlags.memory, "mem", 1, "Memory (GB)")
 	serverCreateCmd.Flags().IntVar(&serverFlags.cores, "cores", 1, "No. of cores")
 	serverCreateCmd.Flags().IntVar(&serverFlags.storageSize, "storage-size", 10, "Storage capacity (GB)")
-	serverCreateCmd.Flags().StringVar(&serverFlags.serverName, "name", "", "Name of the server")
+	serverCreateCmd.Flags().StringVarP(&serverFlags.serverName, "name", "n", "", "Name of the server")
 	serverCreateCmd.Flags().StringVar(&serverFlags.template, "with-template", "", "Name or ID of template to use")
 	serverCreateCmd.Flags().StringVar(&serverFlags.hostName, "hostname", "", "Hostname")
 	serverCreateCmd.Flags().StringVar(&serverFlags.profile, "profile", "q35", "Hardware profile")
@@ -510,7 +510,7 @@ func init() {
 
 	serverSetCmd.Flags().IntVar(&serverFlags.memory, "mem", 0, "Memory (GB)")
 	serverSetCmd.Flags().IntVar(&serverFlags.cores, "cores", 0, "No. of cores")
-	serverSetCmd.Flags().StringVar(&serverFlags.serverName, "name", "", "Name of the server")
+	serverSetCmd.Flags().StringVarP(&serverFlags.serverName, "name", "n", "", "Name of the server")
 
 	serverRmCmd.Flags().BoolVarP(&serverFlags.includeRelated, "include-related", "i", false, "Remove all objects currently related to this server, not just the server")
 	serverRmCmd.Flags().BoolVarP(&serverFlags.force, "force", "f", false, "Force a destructive operation")

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -156,7 +156,7 @@ var storageRmCmd = &cobra.Command{
 
 func init() {
 	storageSetCmd.PersistentFlags().StringVarP(&storageFlags.name, "name", "n", "", "Change name")
-	storageSetCmd.PersistentFlags().IntVarP(&storageFlags.capacity, "capacity", "", 0, "Change size (GB)")
+	storageSetCmd.PersistentFlags().IntVar(&storageFlags.capacity, "capacity", 0, "Change size (GB)")
 	storageSetCmd.PersistentFlags().BoolVarP(&storageFlags.force, "force", "", false, "Force a potential destructive operation")
 
 	storageCmd.AddCommand(storageLsCmd, storageSetCmd, storageRmCmd)

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -157,7 +157,7 @@ var storageRmCmd = &cobra.Command{
 func init() {
 	storageSetCmd.PersistentFlags().StringVarP(&storageFlags.name, "name", "n", "", "Change name")
 	storageSetCmd.PersistentFlags().IntVar(&storageFlags.capacity, "capacity", 0, "Change size (GB)")
-	storageSetCmd.PersistentFlags().BoolVarP(&storageFlags.force, "force", "", false, "Force a potential destructive operation")
+	storageSetCmd.PersistentFlags().BoolVarP(&storageFlags.force, "force", "f", false, "Force a potential destructive operation")
 
 	storageCmd.AddCommand(storageLsCmd, storageSetCmd, storageRmCmd)
 	rootCmd.AddCommand(storageCmd)


### PR DESCRIPTION
By adding shorthands for --name and --force where there were none before, and removing empty shorthands