### PR TITLE
Implement shared credentials across gridscale tools (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ FEATURES:
 * The configuration file format has been changed (see [#153](https://github.com/gridscale/gscloud/pull/153)), but the old one can still be loaded
 * `gscloud move-config` has been added to move the old config to the new path and format
 * `--account` has been renamed to `--project`. `--account` is still working, but deprecated and it will be removed in a future release
+* Added environment variable `GRIDSCALE_PROJECT` that controls the account used
 
 FIXED:
 * GitHub does not support `%(describe)`, yet, so we have to upload release artifacts manually for now (see https://github.community/t/support-for-describe-in-export-subst/196618 and [#131](https://github.com/gridscale/gscloud/issues/131)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## v0.11.1 (2022-XX-XX)
+## v0.12.0 (2022-XX-XX)
 
 FEATURES:
 
 * `gscloud info --json` now includes the sum of total cores, memory, and storage capacity in the output.
+* The configuration file has been moved from `$OS_SPECIFIC_PATH/gscloud/config.yaml` to `$OS_SPECIFIC_PATH/gridscale/config.yaml` for [shared credentials across gridscale tools](https://github.com/gridscale/terraform-provider-gridscale/issues/183)
+* The configuration file format has been changed (see [#153](https://github.com/gridscale/gscloud/pull/153)), but the old one can still be loaded
+* `gscloud move-config` has been added to move the old config to the new path and format
+* `--account` has been renamed to `--project`. `--account` is still working, but deprecated and it will be removed in a future release
 
 FIXED:
 * GitHub does not support `%(describe)`, yet, so we have to upload release artifacts manually for now (see https://github.community/t/support-for-describe-in-export-subst/196618 and [#131](https://github.com/gridscale/gscloud/issues/131)).

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ users:
       command: $HOME/gscloud
       args:
         - "--config"
-        - "$HOME/.config/gscloud/config.yaml"
+        - "$HOME/.config/gridscale/config.yaml"
         - "--project"
         - "test"
         - "kubernetes"

--- a/README.md
+++ b/README.md
@@ -31,13 +31,11 @@ You can use `gscloud make-config` to generate a new config file. Make sure to ad
 Example config:
 
 ```yml
-accounts:
-- account:
-  name: default
+projects:
+- name: default
   userId: 2727b9ab-65ff-4d1e-af5e-d08d682bd1fa
   token: 6eb139b3b6515515a6f358d3a635e9b38f05935782602d4fd5c1b5716af54526
-- account:
-  name: liveaccount
+- name: liveproject
   userId: 2727b9ab-65ff-4d1e-af5e-d08d682bd1fa
   token: 6eb139b3b6515515a6f358d3a635e9b38f05935782602d4fd5c1b5716af54526
   url: https://api.gridscale.io
@@ -71,7 +69,7 @@ users:
       args:
         - "--config"
         - "$HOME/.config/gscloud/config.yaml"
-        - "--account"
+        - "--project"
         - "test"
         - "kubernetes"
         - "cluster"
@@ -87,7 +85,7 @@ gscloud returns zero exit code on success, non-zero on failure. Following exit c
 1. The requested command failed.
 2. Reading the configuration file failed.
 3. The configuration could not be parsed.
-4. The account specified does not exist in the configuration file.
+4. The project specified does not exist in the configuration file.
 
 ## Shell completions
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -52,7 +52,7 @@ Show summary for a given account:
 		}
 
 		conf := rt.Config()
-		for _, account := range conf.Accounts {
+		for _, account := range conf.Projects {
 			accountName := rt.Account()
 			if account.Name == accountName {
 				if !rootFlags.json {

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -16,16 +16,16 @@ import (
 
 var infoCmd = &cobra.Command{
 	Use:   "info",
-	Short: "Print account summary",
-	Long: `Print information about the current account.
+	Short: "Print project summary",
+	Long: `Print information about the current project.
 
 # EXAMPLES
 
-Show summary for a given account:
+Show summary for a given project:
 
-	$ gscloud --account=dev@example.com info
+	$ gscloud --project=dev@example.com info
 	SETTING    VALUE
-	Account    dev@example.com
+	Project    dev@example.com
 	User ID    7ff8003b-55c5-45c5-bf0c-3746735a4f99
 	API token  <redacted>
 	URL        https://api.gridscale.io
@@ -38,7 +38,7 @@ Show summary for a given account:
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		type output struct {
-			runtime.AccountEntry
+			runtime.ProjectEntry
 			ServerAgg  map[string]interface{} `json:"server"`
 			StorageAgg map[string]interface{} `json:"storage"`
 			IPAddrAgg  map[string]interface{} `json:"ip_address"`
@@ -52,17 +52,17 @@ Show summary for a given account:
 		}
 
 		conf := rt.Config()
-		for _, account := range conf.Projects {
-			accountName := rt.Account()
-			if account.Name == accountName {
+		for _, project := range conf.Projects {
+			projectName := rt.Project()
+			if project.Name == projectName {
 				if !rootFlags.json {
 					out := new(bytes.Buffer)
 					heading := []string{"setting", "value"}
 					fill := [][]string{
-						{"Account", account.Name},
-						{"User ID", account.UserID},
-						{"API token", account.Token},
-						{"URL", account.URL},
+						{"Project", project.Name},
+						{"User ID", project.UserID},
+						{"API token", project.Token},
+						{"URL", project.URL},
 					}
 					var rows [][]string
 					rows = append(rows, fill...)
@@ -173,7 +173,7 @@ Show summary for a given account:
 					}
 
 					jsonOutput := output{
-						AccountEntry: account,
+						ProjectEntry: project,
 						ServerAgg:    m["Servers"],
 						StorageAgg:   m["Storages"],
 						IPAddrAgg:    m["IP addresses"],

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -152,8 +152,8 @@ KUBECONFIG
 					Args: []string{
 						"--config",
 						runtime.ConfigPath(),
-						"--account",
-						rt.Account(),
+						"--project",
+						rt.Project(),
 						"kubernetes",
 						"cluster",
 						"exec-credential",

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gridscale/gscloud/utils"
 	"github.com/kardianos/osext"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientauth "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
@@ -151,7 +152,7 @@ KUBECONFIG
 					Command:    executablePath(),
 					Args: []string{
 						"--config",
-						runtime.ConfigPath(),
+						viper.ConfigFileUsed(),
 						"--project",
 						rt.Project(),
 						"kubernetes",

--- a/cmd/makeConfig.go
+++ b/cmd/makeConfig.go
@@ -32,7 +32,7 @@ Create a new configuration file at a specified path:
 		}
 
 		if !utils.FileExists(filePath) {
-			runtime.WriteConfig(&runtime.Config{Projects: []runtime.ProjectEntry{{}}}, filePath)
+			runtime.WriteConfig(&runtime.Config{Projects: []runtime.ProjectEntry{{URL: defaultAPIURL}}}, filePath)
 
 			fmt.Printf("Written: %s\n", filePath)
 		}

--- a/cmd/makeConfig.go
+++ b/cmd/makeConfig.go
@@ -60,7 +60,7 @@ func emptyConfig() []byte {
 		URL:    defaultAPIURL,
 	}
 	c := runtime.Config{
-		Accounts: []runtime.AccountEntry{defaultAccount},
+		Projects: []runtime.AccountEntry{defaultAccount},
 	}
 	out, _ := yaml.Marshal(&c)
 	return out

--- a/cmd/makeConfig.go
+++ b/cmd/makeConfig.go
@@ -51,16 +51,16 @@ func init() {
 	rootCmd.AddCommand(makeConfigCmd)
 }
 
-// emptyConfig creates a new config YAML with a 'default' account.
+// emptyConfig creates a new config YAML with a 'default' project
 func emptyConfig() []byte {
-	defaultAccount := runtime.AccountEntry{
+	defaultProject := runtime.ProjectEntry{
 		Name:   "default",
 		UserID: "",
 		Token:  "",
 		URL:    defaultAPIURL,
 	}
 	c := runtime.Config{
-		Projects: []runtime.AccountEntry{defaultAccount},
+		Projects: []runtime.ProjectEntry{defaultProject},
 	}
 	out, _ := yaml.Marshal(&c)
 	return out

--- a/cmd/makeConfig.go
+++ b/cmd/makeConfig.go
@@ -2,20 +2,16 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 
 	"github.com/gridscale/gscloud/runtime"
 	"github.com/gridscale/gscloud/utils"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 )
 
 var makeConfigCmd = &cobra.Command{
 	Use:   "make-config",
 	Short: "Create a new configuration file",
-	Long: fmt.Sprintf(`Create a new and possibly almost empty configuration file overwriting an existing one if it exists. Prints the path to the newly created file to stdout.
+	Long: fmt.Sprintf(`Create a new and possibly almost empty configuration file not overwriting an existing one if it exists. Prints the path to the newly created file to stdout.
 
 # EXAMPLES
 
@@ -31,37 +27,19 @@ Create a new configuration file at a specified path:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		filePath := runtime.ConfigPath()
 
-		if !utils.FileExists(filePath) {
-			err := os.MkdirAll(filepath.Dir(filePath), os.FileMode(0700))
-			if err != nil {
-				return err
-			}
-
-			err = ioutil.WriteFile(filePath, emptyConfig(), 0644)
-			if err != nil {
-				return err
-			}
+		if rootFlags.configFile != "" {
+			filePath = rootFlags.configFile
 		}
-		fmt.Printf("Written: %s\n", filePath)
+
+		if !utils.FileExists(filePath) {
+			runtime.WriteConfig(&runtime.Config{Projects: []runtime.ProjectEntry{{}}}, filePath)
+
+			fmt.Printf("Written: %s\n", filePath)
+		}
 		return nil
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(makeConfigCmd)
-}
-
-// emptyConfig creates a new config YAML with a 'default' project
-func emptyConfig() []byte {
-	defaultProject := runtime.ProjectEntry{
-		Name:   "default",
-		UserID: "",
-		Token:  "",
-		URL:    defaultAPIURL,
-	}
-	c := runtime.Config{
-		Projects: []runtime.ProjectEntry{defaultProject},
-	}
-	out, _ := yaml.Marshal(&c)
-	return out
 }

--- a/cmd/moveConfig.go
+++ b/cmd/moveConfig.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/gridscale/gscloud/runtime"
+	"github.com/gridscale/gscloud/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type moveConfigCmdFlags struct {
+	force bool
+}
+
+var moveConfigFlags moveConfigCmdFlags
+
+var moveConfigCmd = &cobra.Command{
+	Use:   "move-config",
+	Short: "Move an old config file to the current path",
+	Long: fmt.Sprintf(`Move an old config file (like at %s) to the current position (%s), 
+ while updating it's contents to match the current format. Doesn't override the old config when --force is not given`,
+		runtime.OldConfigPathWithoutUser(), runtime.ConfigPathWithoutUser()),
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		viper.SetConfigFile(runtime.OldConfigPath())
+
+		if err := viper.ReadInConfig(); err != nil {
+			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+				log.Infoln("Old config not found, stopping")
+				return nil
+			}
+			return err
+		}
+
+		if utils.FileExists(runtime.ConfigPath()) && !moveConfigFlags.force {
+			log.Errorf("This action would overwrite %s. Run with --force to force this\n", runtime.ConfigPath())
+			return nil
+		}
+
+		conf, err := runtime.ParseConfig()
+
+		if err != nil {
+			return err
+		}
+
+		return runtime.WriteConfig(conf, runtime.ConfigPath())
+	},
+}
+
+func init() {
+	moveConfigCmd.Flags().BoolVarP(&moveConfigFlags.force, "force", "f", false, "Force overwriting old config files")
+
+	rootCmd.AddCommand(moveConfigCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ func NewError(cmd *cobra.Command, what string, err error) *Error {
 
 type rootCmdFlags struct {
 	configFile string
-	account    string
+	project    string
 	json       bool
 	quiet      bool
 	debug      bool
@@ -67,7 +67,7 @@ gscloud returns zero exit code on success, non-zero on failure. Following exit c
     1. The requested command failed.
     2. Reading the configuration file failed.
     3. The configuration could not be parsed.
-    4. The account specified does not exist in the configuration file.
+    4. The project specified does not exist in the configuration file.
 
 # EXAMPLES
 
@@ -130,8 +130,8 @@ Get the list of storages as JSON:
 
 # ENVIRONMENT
 
-GRIDSCALE_ACCOUNT
-	Specify the account used. Gets overriden by --account option
+GRIDSCALE_PROJECT
+	Specify the project used. Gets overriden by --project option
 
 GRIDSCALE_UUID
 	Specify the user id used. Overrides the value in the config file
@@ -167,13 +167,13 @@ func init() {
 	rootCmd.SilenceUsage = true
 	rootCmd.SilenceErrors = true
 
-	account, accountEnvPresent := os.LookupEnv("GRIDSCALE_ACCOUNT")
-	if !accountEnvPresent {
-		account = "default"
+	project, projectEnvPresent := os.LookupEnv("GRIDSCALE_PROJECT")
+	if !projectEnvPresent {
+		project = "default"
 	}
 
 	rootCmd.PersistentFlags().StringVar(&rootFlags.configFile, "config", runtime.ConfigPathWithoutUser(), "Path to configuration file")
-	rootCmd.PersistentFlags().StringVar(&rootFlags.account, "account", account, "Specify the account used. Overrides GRIDSCALE_ACCOUNT environment variable")
+	rootCmd.PersistentFlags().StringVar(&rootFlags.project, "project", project, "Specify the project used. Overrides GRIDSCALE_PROJECT environment variable")
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.json, "json", "j", false, "Print JSON to stdout instead of a table")
 	rootCmd.PersistentFlags().BoolVar(&renderOpts.NoHeader, "noheading", false, "Do not print column headings")
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.quiet, "quiet", "q", false, "Print only object IDs")
@@ -207,14 +207,14 @@ func initConfig() {
 	}
 }
 
-// initRuntime initializes the client for a given account.
+// initRuntime initializes the client for a given project
 func initRuntime() {
 	conf, err := runtime.ParseConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(3)
 	}
-	theRuntime, err := runtime.NewRuntime(*conf, rootFlags.account, CommandWithoutConfig(os.Args))
+	theRuntime, err := runtime.NewRuntime(*conf, rootFlags.project, CommandWithoutConfig(os.Args))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(4)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,9 +41,7 @@ var (
 	rt         *runtime.Runtime
 )
 
-const (
-	defaultAPIURL = "https://api.gridscale.io"
-)
+const defaultAPIURL = "https://api.gridscale.io"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ func NewError(cmd *cobra.Command, what string, err error) *Error {
 type rootCmdFlags struct {
 	configFile string
 	project    string
+	account    string // Deprecated
 	json       bool
 	quiet      bool
 	debug      bool
@@ -173,7 +174,9 @@ func init() {
 	}
 
 	rootCmd.PersistentFlags().StringVar(&rootFlags.configFile, "config", "", "Path to configuration file")
-	rootCmd.PersistentFlags().StringVar(&rootFlags.project, "project", project, "Specify the project used. Overrides GRIDSCALE_PROJECT environment variable")
+	rootCmd.PersistentFlags().StringVar(&rootFlags.project, "project", "", "Specify the project used. Overrides GRIDSCALE_PROJECT environment variable")
+	rootCmd.PersistentFlags().StringVar(&rootFlags.account, "account", project, "Specify the project used. Is overriden by --project. Deprecated")
+	rootCmd.PersistentFlags().MarkDeprecated("account", "it will be removed in a future update!")
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.json, "json", "j", false, "Print JSON to stdout instead of a table")
 	rootCmd.PersistentFlags().BoolVar(&renderOpts.NoHeader, "noheading", false, "Do not print column headings")
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.quiet, "quiet", "q", false, "Print only object IDs")
@@ -221,6 +224,11 @@ func initRuntime() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(3)
 	}
+
+	if rootFlags.project == "" && rootFlags.account != "" {
+		rootFlags.project = rootFlags.account
+	}
+
 	theRuntime, err := runtime.NewRuntime(*conf, rootFlags.project, CommandWithoutConfig(os.Args))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -194,7 +194,7 @@ func initConfig() {
 		viper.SetConfigName("config")
 		viper.SetConfigType("yaml")
 
-		if !utils.FileExists(runtime.ConfigPath()) && utils.FileExists(runtime.OldConfigPath()) {
+		if !utils.FileExists(runtime.ConfigPath()) && utils.FileExists(runtime.OldConfigPath()) && !CommandWithoutConfig(os.Args) {
 			viper.SetConfigFile(runtime.OldConfigPath())
 			log.Warnln("Using deprecated old config file. Use `gscloud make-config --move` to move to the new one")
 		} else {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -172,7 +172,7 @@ func init() {
 		project = "default"
 	}
 
-	rootCmd.PersistentFlags().StringVar(&rootFlags.configFile, "config", runtime.ConfigPathWithoutUser(), "Path to configuration file")
+	rootCmd.PersistentFlags().StringVar(&rootFlags.configFile, "config", "", "Path to configuration file")
 	rootCmd.PersistentFlags().StringVar(&rootFlags.project, "project", project, "Specify the project used. Overrides GRIDSCALE_PROJECT environment variable")
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.json, "json", "j", false, "Print JSON to stdout instead of a table")
 	rootCmd.PersistentFlags().BoolVar(&renderOpts.NoHeader, "noheading", false, "Do not print column headings")
@@ -190,7 +190,14 @@ func initConfig() {
 		// Use default paths.
 		viper.SetConfigName("config")
 		viper.SetConfigType("yaml")
-		viper.AddConfigPath(runtime.ConfigPath())
+
+		if !utils.FileExists(runtime.ConfigPath()) && utils.FileExists(runtime.OldConfigPath()) {
+			viper.SetConfigFile(runtime.OldConfigPath())
+			log.Warnln("Using deprecated old config file. Use `gscloud make-config --move` to move to the new one")
+		} else {
+			viper.AddConfigPath(runtime.ConfigPath())
+		}
+
 		viper.AddConfigPath(".")
 	}
 	viper.AutomaticEnv() // read in environment variables that match

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -261,7 +261,7 @@ func initLogging() {
 // command line again.
 func CommandWithoutConfig(cmdLine []string) bool {
 	noConfigNeeded := []string{
-		"make-config", "version", "manpage", "completion",
+		"make-config", "version", "manpage", "completion", "move-config",
 	}
 
 	foundCommand, _, _ := rootCmd.Find(cmdLine[1:])

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -20,7 +20,7 @@ func Test_CommandWithoutConfig(t *testing.T) {
 			Expected: false,
 		},
 		{
-			Args:     []string{"gscloud", "server", "create", "--account", "completion"},
+			Args:     []string{"gscloud", "server", "create", "--project", "completion"},
 			Expected: false,
 		},
 		{

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -28,7 +28,7 @@ func init() {
 	origHelpFunc := versionCmd.HelpFunc()
 	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		if cmd.Name() == "version" || (cmd.HasParent() && cmd.Parent().Name() == "version") {
-			cmd.Flags().MarkHidden("account")
+			cmd.Flags().MarkHidden("project")
 			cmd.Flags().MarkHidden("config")
 			cmd.Flags().MarkHidden("json")
 			cmd.Flags().MarkHidden("quiet")

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -18,6 +18,11 @@ type Config struct {
 	Projects []ProjectEntry `yaml:"projects"`
 }
 
+// OldConfig are all configuration settings parsed from an old configuration file
+type OldConfig struct {
+	Accounts []ProjectEntry `yaml:"accounts"`
+}
+
 const oldConfigPath = "/gscloud/config.yaml"
 const configPath = "/gridscale/config.yaml"
 

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	Accounts []AccountEntry `yaml:"accounts"`
 }
 
+const configPath = "/gridscale/config.yaml"
+
 // ConfigPath construct platform specific path to the configuration file.
 // - on Linux: $XDG_CONFIG_HOME or $HOME/.config
 // - on macOS: $HOME/Library/Application Support
@@ -25,7 +27,7 @@ type Config struct {
 func ConfigPath() string {
 	path := viper.ConfigFileUsed()
 	if path == "" {
-		path = configdir.LocalConfig("gscloud") + "/config.yaml"
+		path = configdir.LocalConfig() + configPath
 		viper.SetConfigFile(path)
 	}
 	return path
@@ -33,7 +35,7 @@ func ConfigPath() string {
 
 // ConfigPathWithoutUser same as ConfigPath but with environment variables not expanded.
 func ConfigPathWithoutUser() string {
-	return localConfig + "/gscloud/config.yaml"
+	return localConfig + configPath
 }
 
 // ParseConfig parses viper config file.

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -18,12 +18,14 @@ type Config struct {
 	Projects []ProjectEntry `yaml:"projects"`
 }
 
+const oldConfigPath = "/gscloud/config.yaml"
 const configPath = "/gridscale/config.yaml"
 
 // ConfigPath constructs the platform specific path to the configuration file.
 // - on Linux: $XDG_CONFIG_HOME or $HOME/.config
 // - on macOS: $HOME/Library/Application Support
 // - on Windows: %APPDATA% or "C:\\Users\\%USER%\\AppData\\Roaming"
+// Right now this has the side effect of calling viper.SetConfigFile()
 func ConfigPath() string {
 	path := viper.ConfigFileUsed()
 	if path == "" {
@@ -36,6 +38,10 @@ func ConfigPath() string {
 // ConfigPathWithoutUser is the same as ConfigPath but with environment variables not expanded.
 func ConfigPathWithoutUser() string {
 	return localConfig + configPath
+}
+
+func OldConfigPath() string {
+	return configdir.LocalConfig() + oldConfigPath
 }
 
 // ParseConfig parses viper config file.

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -1,8 +1,13 @@
 package runtime
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	"github.com/kirsle/configdir"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
 )
 
 // ProjectEntry represents a single project in the config file
@@ -64,4 +69,20 @@ func ParseConfig() (*Config, error) {
 	}
 
 	return &conf, nil
+}
+
+func WriteConfig(conf *Config, filePath string) error {
+	err := os.MkdirAll(filepath.Dir(filePath), os.FileMode(0700))
+	if err != nil {
+		return err
+	}
+
+	c, _ := yaml.Marshal(conf)
+
+	err = ioutil.WriteFile(filePath, c, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -30,14 +30,8 @@ const configPath = "/gridscale/config.yaml"
 // - on Linux: $XDG_CONFIG_HOME or $HOME/.config
 // - on macOS: $HOME/Library/Application Support
 // - on Windows: %APPDATA% or "C:\\Users\\%USER%\\AppData\\Roaming"
-// Right now this has the side effect of calling viper.SetConfigFile()
 func ConfigPath() string {
-	path := viper.ConfigFileUsed()
-	if path == "" {
-		path = configdir.LocalConfig() + configPath
-		viper.SetConfigFile(path)
-	}
-	return path
+	return configdir.LocalConfig() + configPath
 }
 
 // ConfigPathWithoutUser is the same as ConfigPath but with environment variables not expanded.

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -53,8 +53,17 @@ func OldConfigPath() string {
 func ParseConfig() (*Config, error) {
 	conf := Config{}
 	err := viper.Unmarshal(&conf)
+
 	if err != nil {
 		return nil, err
 	}
+
+	if conf.Projects == nil {
+		oldConf := OldConfig{}
+		viper.Unmarshal(&oldConf)
+
+		conf.Projects = oldConf.Accounts
+	}
+
 	return &conf, nil
 }

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -49,6 +49,10 @@ func OldConfigPath() string {
 	return configdir.LocalConfig() + oldConfigPath
 }
 
+func OldConfigPathWithoutUser() string {
+	return localConfig + oldConfigPath
+}
+
 // ParseConfig parses viper config file.
 func ParseConfig() (*Config, error) {
 	conf := Config{}

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -20,7 +20,7 @@ type Config struct {
 
 const configPath = "/gridscale/config.yaml"
 
-// ConfigPath construct platform specific path to the configuration file.
+// ConfigPath constructs the platform specific path to the configuration file.
 // - on Linux: $XDG_CONFIG_HOME or $HOME/.config
 // - on macOS: $HOME/Library/Application Support
 // - on Windows: %APPDATA% or "C:\\Users\\%USER%\\AppData\\Roaming"
@@ -33,7 +33,7 @@ func ConfigPath() string {
 	return path
 }
 
-// ConfigPathWithoutUser same as ConfigPath but with environment variables not expanded.
+// ConfigPathWithoutUser is the same as ConfigPath but with environment variables not expanded.
 func ConfigPathWithoutUser() string {
 	return localConfig + configPath
 }

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -15,7 +15,7 @@ type AccountEntry struct {
 
 // Config are all configuration settings parsed from a configuration file.
 type Config struct {
-	Accounts []AccountEntry `yaml:"accounts"`
+	Accounts []AccountEntry `yaml:"projects"`
 }
 
 const configPath = "/gridscale/config.yaml"

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -5,8 +5,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-// AccountEntry represents a single account in the config file.
-type AccountEntry struct {
+// ProjectEntry represents a single project in the config file
+type ProjectEntry struct {
 	Name   string `yaml:"name" json:"name"`
 	UserID string `yaml:"userId" json:"userId"`
 	Token  string `yaml:"token" json:"token"`
@@ -15,7 +15,7 @@ type AccountEntry struct {
 
 // Config are all configuration settings parsed from a configuration file.
 type Config struct {
-	Projects []AccountEntry `yaml:"projects"`
+	Projects []ProjectEntry `yaml:"projects"`
 }
 
 const configPath = "/gridscale/config.yaml"

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -15,7 +15,7 @@ type AccountEntry struct {
 
 // Config are all configuration settings parsed from a configuration file.
 type Config struct {
-	Accounts []AccountEntry `yaml:"projects"`
+	Projects []AccountEntry `yaml:"projects"`
 }
 
 const configPath = "/gridscale/config.yaml"

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -220,7 +220,7 @@ func NewRuntime(conf Config, accountName string, commandWithoutConfig bool) (*Ru
 	var ac AccountEntry
 	var accountIndex = -1
 
-	for i, a := range conf.Accounts {
+	for i, a := range conf.Projects {
 		if accountName == a.Name {
 			ac = a
 			accountIndex = i
@@ -229,12 +229,12 @@ func NewRuntime(conf Config, accountName string, commandWithoutConfig bool) (*Ru
 	}
 
 	if accountIndex == -1 {
-		if len(conf.Accounts) > 0 && !commandWithoutConfig {
+		if len(conf.Projects) > 0 && !commandWithoutConfig {
 			return nil, fmt.Errorf("account '%s' does not exist", accountName)
 		}
 	} else {
 		ac = LoadEnvVariables(ac)
-		conf.Accounts[accountIndex] = ac
+		conf.Projects[accountIndex] = ac
 	}
 
 	client := newClient(ac)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -70,7 +70,7 @@ func Test_NewRuntime(t *testing.T) {
 		assert.Equal(t, test.ExpectedRuntimeIsNil, rt == nil)
 
 		if rt != nil {
-			for _, ac := range rt.config.Accounts {
+			for _, ac := range rt.config.Projects {
 				if ac.Name == rt.accountName {
 					assert.Equal(t, test.ExpectedAccount, ac)
 					break

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -11,14 +11,14 @@ import (
 func Test_NewRuntime(t *testing.T) {
 	type testCase struct {
 		Configuration        Config
-		AccountName          string
+		ProjectName          string
 		Environment          []string
 		ExpectedRuntimeIsNil bool
-		ExpectedAccount      AccountEntry
+		ExpectedProject      ProjectEntry
 		ExpectedErrorIsNil   bool
 	}
 
-	testAccount := AccountEntry{
+	testProject := ProjectEntry{
 		Name:   "test",
 		UserID: "test",
 		Token:  "test",
@@ -27,35 +27,35 @@ func Test_NewRuntime(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			Configuration:        Config{[]AccountEntry{testAccount}},
-			AccountName:          testAccount.Name,
+			Configuration:        Config{[]ProjectEntry{testProject}},
+			ProjectName:          testProject.Name,
 			Environment:          []string{},
 			ExpectedRuntimeIsNil: false,
-			ExpectedAccount:      testAccount,
+			ExpectedProject:      testProject,
 			ExpectedErrorIsNil:   true,
 		},
 		{
-			Configuration:        Config{[]AccountEntry{testAccount}},
-			AccountName:          "default",
+			Configuration:        Config{[]ProjectEntry{testProject}},
+			ProjectName:          "default",
 			Environment:          []string{},
 			ExpectedRuntimeIsNil: true,
-			ExpectedAccount:      AccountEntry{},
+			ExpectedProject:      ProjectEntry{},
 			ExpectedErrorIsNil:   false,
 		},
 		{
-			Configuration:        Config{[]AccountEntry{}},
-			AccountName:          "default",
+			Configuration:        Config{[]ProjectEntry{}},
+			ProjectName:          "default",
 			Environment:          []string{},
 			ExpectedRuntimeIsNil: false,
-			ExpectedAccount:      AccountEntry{},
+			ExpectedProject:      ProjectEntry{},
 			ExpectedErrorIsNil:   true,
 		},
 		{
-			Configuration:        Config{[]AccountEntry{testAccount}},
-			AccountName:          testAccount.Name,
+			Configuration:        Config{[]ProjectEntry{testProject}},
+			ProjectName:          testProject.Name,
 			Environment:          []string{"GRIDSCALE_UUID=envUserId", "GRIDSCALE_TOKEN=envToken", "GRIDSCALE_URL=env.example.com"},
 			ExpectedRuntimeIsNil: false,
-			ExpectedAccount:      AccountEntry{Name: testAccount.Name, UserID: "envUserId", Token: "envToken", URL: "env.example.com"},
+			ExpectedProject:      ProjectEntry{Name: testProject.Name, UserID: "envUserId", Token: "envToken", URL: "env.example.com"},
 			ExpectedErrorIsNil:   true,
 		},
 	}
@@ -64,15 +64,15 @@ func Test_NewRuntime(t *testing.T) {
 		oldEnviron := os.Environ()
 		resetEnv(test.Environment)
 
-		rt, err := NewRuntime(test.Configuration, test.AccountName, false)
+		rt, err := NewRuntime(test.Configuration, test.ProjectName, false)
 
 		assert.Equal(t, test.ExpectedErrorIsNil, err == nil)
 		assert.Equal(t, test.ExpectedRuntimeIsNil, rt == nil)
 
 		if rt != nil {
 			for _, ac := range rt.config.Projects {
-				if ac.Name == rt.accountName {
-					assert.Equal(t, test.ExpectedAccount, ac)
+				if ac.Name == rt.ProjectName {
+					assert.Equal(t, test.ExpectedProject, ac)
 					break
 				}
 			}


### PR DESCRIPTION
1. Changes the config path from `/gscloud/config.yaml` to `/gridscale/config.yaml` and
2. Changes the config contents from
```
accounts:
- name: default
  userId: xyz
  token: xyz
  url: https://api.gridscale.io
- name: somthing-else
  userId: xyz
  token: xyz
  url: https://api.gridscale.io
```
to
```
projects:
- name: default
  userId: xyz
  token: xyz
  url: https://api.gridscale.io
- name: somthing-else
  userId: xyz
  token: xyz
  url: https://api.gridscale.io
```
as proposed in #136 

Changes the name of `--account` flag and `GRIDSCALE_ACCOUNT` environment variable to `--project` and `GRIDSCALE_PROJECT` respectively for consistency reasons

There will be no compatibility to `GRIDSCALE_ACCOUNT` as it wasn't part of the [last release](https://github.com/gridscale/gscloud/releases/tag/v0.11.0), but `--account` will still be usable, though deprecated and lower priority than `--project`

The old config path/contents can still be loaded, but the user will be warned of deprecation

`gscloud move-config` will be introduced. copying and converting the old config to the new one