### PR TITLE
Improve account handling in Runtime

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -53,10 +53,6 @@ Show summary for a given account:
 
 		account := rt.Account()
 
-		if account == nil {
-			panic("unexpected nil account")
-		}
-
 		if !rootFlags.json {
 			out := new(bytes.Buffer)
 			heading := []string{"setting", "value"}
@@ -175,7 +171,7 @@ Show summary for a given account:
 			}
 
 			jsonOutput := output{
-				AccountEntry: *account,
+				AccountEntry: account,
 				ServerAgg:    m["Servers"],
 				StorageAgg:   m["Storages"],
 				IPAddrAgg:    m["IP addresses"],

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -53,7 +53,7 @@ Show summary for a given account:
 
 		conf := rt.Config()
 		for _, account := range conf.Accounts {
-			accountName := rt.Account()
+			accountName := rt.AccountName()
 			if account.Name == accountName {
 				if !rootFlags.json {
 					out := new(bytes.Buffer)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -130,11 +130,6 @@ Show summary for a given account:
 		var wg sync.WaitGroup
 		ch := make(chan objectCount)
 
-		go func() {
-			wg.Wait()
-			close(ch)
-		}()
-
 		for k, v := range funcs {
 			wg.Add(1)
 			cCopy := context.Background()
@@ -148,6 +143,11 @@ Show summary for a given account:
 				ch <- objectCount{obj, agg, nil}
 			}(k, v)
 		}
+
+		go func() {
+			wg.Wait()
+			close(ch)
+		}()
 
 		out := new(bytes.Buffer)
 		if !rootFlags.json {

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -51,139 +51,139 @@ Show summary for a given account:
 			Err error
 		}
 
-		conf := rt.Config()
-		for _, account := range conf.Accounts {
-			accountName := rt.AccountName()
-			if account.Name == accountName {
-				if !rootFlags.json {
-					out := new(bytes.Buffer)
-					heading := []string{"setting", "value"}
-					fill := [][]string{
-						{"Account", account.Name},
-						{"User ID", account.UserID},
-						{"API token", account.Token},
-						{"URL", account.URL},
-					}
-					var rows [][]string
-					rows = append(rows, fill...)
-					render.AsTable(out, heading, rows, renderOpts)
-					fmt.Print(out)
-				}
+		account := rt.Account()
 
-				fmt.Fprintln(os.Stderr, "Getting information about used resources…")
-				client := rt.Client()
-
-				funcs := map[string]func(context.Context, *gsclient.Client) (map[string]interface{}, error){
-					"Servers": func(ctx context.Context, c *gsclient.Client) (map[string]interface{}, error) {
-						objs, err := c.GetServerList(ctx)
-						if err != nil {
-							return nil, err
-						}
-						mem := 0
-						cores := 0
-						for _, obj := range objs {
-							mem += obj.Properties.Memory
-							cores += obj.Properties.Cores
-						}
-						return map[string]interface{}{
-								"count":  len(objs),
-								"memory": mem,
-								"cores":  cores,
-							},
-							nil
-					},
-					"Storages": func(ctx context.Context, c *gsclient.Client) (map[string]interface{}, error) {
-						objs, err := c.GetStorageList(ctx)
-						if err != nil {
-							return nil, err
-						}
-						capacity := 0
-						for _, obj := range objs {
-							capacity += obj.Properties.Capacity
-						}
-						return map[string]interface{}{
-								"count":    len(objs),
-								"capacity": capacity,
-							},
-							nil
-					},
-					"IP addresses": func(ctx context.Context, c *gsclient.Client) (map[string]interface{}, error) {
-						objs, err := c.GetIPList(ctx)
-						if err != nil {
-							return nil, err
-						}
-						return map[string]interface{}{
-								"count": len(objs),
-							},
-							nil
-					},
-					"Platform services": func(ctx context.Context, c *gsclient.Client) (map[string]interface{}, error) {
-						objs, err := c.GetPaaSServiceList(ctx)
-						if err != nil {
-							return nil, err
-						}
-						return map[string]interface{}{
-								"count": len(objs),
-							},
-							nil
-					},
-				}
-
-				var wg sync.WaitGroup
-				ch := make(chan objectCount)
-
-				for k, v := range funcs {
-					wg.Add(1)
-					cCopy := context.Background()
-					go func(obj string, f func(context.Context, *gsclient.Client) (map[string]interface{}, error)) {
-						defer wg.Done()
-
-						agg, err := f(cCopy, client)
-						if err != nil {
-							ch <- objectCount{obj, nil, NewError(cmd, fmt.Sprintf("Could not get %s", obj), err)}
-						}
-						ch <- objectCount{obj, agg, nil}
-					}(k, v)
-				}
-
-				go func() {
-					wg.Wait()
-					close(ch)
-				}()
-
-				out := new(bytes.Buffer)
-				if !rootFlags.json {
-					heading := []string{"object", "count"}
-					var rows [][]string
-					for v := range ch {
-						if v.Err != nil {
-							return v.Err
-						}
-						count := v.Agg["count"].(int)
-						rows = append(rows, []string{v.Obj, strconv.Itoa(count)})
-					}
-					render.AsTable(out, heading, rows, renderOpts)
-				} else {
-					m := map[string]map[string]interface{}{}
-					for v := range ch {
-						if v.Err != nil {
-							return v.Err
-						}
-						m[v.Obj] = v.Agg
-					}
-
-					jsonOutput := output{
-						AccountEntry: account,
-						ServerAgg:    m["Servers"],
-						StorageAgg:   m["Storages"],
-						IPAddrAgg:    m["IP addresses"],
-						PaasAgg:      m["Platform services"],
-					}
-					render.AsJSON(out, jsonOutput)
-				}
-				fmt.Print(out)
-			}
+		if account == nil {
+			panic("unexpected nil account")
 		}
+
+		if !rootFlags.json {
+			out := new(bytes.Buffer)
+			heading := []string{"setting", "value"}
+			fill := [][]string{
+				{"Account", account.Name},
+				{"User ID", account.UserID},
+				{"API token", account.Token},
+				{"URL", account.URL},
+			}
+			var rows [][]string
+			rows = append(rows, fill...)
+			render.AsTable(out, heading, rows, renderOpts)
+			fmt.Print(out)
+		}
+
+		fmt.Fprintln(os.Stderr, "Getting information about used resources…")
+		client := rt.Client()
+
+		funcs := map[string]func(context.Context, *gsclient.Client) (map[string]interface{}, error){
+			"Servers": func(ctx context.Context, c *gsclient.Client) (map[string]interface{}, error) {
+				objs, err := c.GetServerList(ctx)
+				if err != nil {
+					return nil, err
+				}
+				mem := 0
+				cores := 0
+				for _, obj := range objs {
+					mem += obj.Properties.Memory
+					cores += obj.Properties.Cores
+				}
+				return map[string]interface{}{
+						"count":  len(objs),
+						"memory": mem,
+						"cores":  cores,
+					},
+					nil
+			},
+			"Storages": func(ctx context.Context, c *gsclient.Client) (map[string]interface{}, error) {
+				objs, err := c.GetStorageList(ctx)
+				if err != nil {
+					return nil, err
+				}
+				capacity := 0
+				for _, obj := range objs {
+					capacity += obj.Properties.Capacity
+				}
+				return map[string]interface{}{
+						"count":    len(objs),
+						"capacity": capacity,
+					},
+					nil
+			},
+			"IP addresses": func(ctx context.Context, c *gsclient.Client) (map[string]interface{}, error) {
+				objs, err := c.GetIPList(ctx)
+				if err != nil {
+					return nil, err
+				}
+				return map[string]interface{}{
+						"count": len(objs),
+					},
+					nil
+			},
+			"Platform services": func(ctx context.Context, c *gsclient.Client) (map[string]interface{}, error) {
+				objs, err := c.GetPaaSServiceList(ctx)
+				if err != nil {
+					return nil, err
+				}
+				return map[string]interface{}{
+						"count": len(objs),
+					},
+					nil
+			},
+		}
+
+		var wg sync.WaitGroup
+		ch := make(chan objectCount)
+
+		go func() {
+			wg.Wait()
+			close(ch)
+		}()
+
+		for k, v := range funcs {
+			wg.Add(1)
+			cCopy := context.Background()
+			go func(obj string, f func(context.Context, *gsclient.Client) (map[string]interface{}, error)) {
+				defer wg.Done()
+
+				agg, err := f(cCopy, client)
+				if err != nil {
+					ch <- objectCount{obj, nil, NewError(cmd, fmt.Sprintf("Could not get %s", obj), err)}
+				}
+				ch <- objectCount{obj, agg, nil}
+			}(k, v)
+		}
+
+		out := new(bytes.Buffer)
+		if !rootFlags.json {
+			heading := []string{"object", "count"}
+			var rows [][]string
+			for v := range ch {
+				if v.Err != nil {
+					return v.Err
+				}
+				count := v.Agg["count"].(int)
+				rows = append(rows, []string{v.Obj, strconv.Itoa(count)})
+			}
+			render.AsTable(out, heading, rows, renderOpts)
+		} else {
+			m := map[string]map[string]interface{}{}
+			for v := range ch {
+				if v.Err != nil {
+					return v.Err
+				}
+				m[v.Obj] = v.Agg
+			}
+
+			jsonOutput := output{
+				AccountEntry: *account,
+				ServerAgg:    m["Servers"],
+				StorageAgg:   m["Storages"],
+				IPAddrAgg:    m["IP addresses"],
+				PaasAgg:      m["Platform services"],
+			}
+			render.AsJSON(out, jsonOutput)
+		}
+		fmt.Print(out)
 		return nil
 	},
 }

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -145,10 +145,6 @@ KUBECONFIG
 			ClientKey:         u.User.ClientCertificateData,
 		}
 		if credentialPlugin {
-			if rt.Account() == nil {
-				panic("unexpected nil account")
-			}
-
 			currentKubeConfig.AuthInfos[u.Name] = &clientcmdapi.AuthInfo{
 				Exec: &clientcmdapi.ExecConfig{
 					APIVersion: clientauth.SchemeGroupVersion.String(),

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -153,7 +153,7 @@ KUBECONFIG
 						"--config",
 						runtime.ConfigPath(),
 						"--account",
-						rt.Account(),
+						rt.AccountName(),
 						"kubernetes",
 						"cluster",
 						"exec-credential",

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -145,6 +145,10 @@ KUBECONFIG
 			ClientKey:         u.User.ClientCertificateData,
 		}
 		if credentialPlugin {
+			if rt.Account() == nil {
+				panic("unexpected nil account")
+			}
+
 			currentKubeConfig.AuthInfos[u.Name] = &clientcmdapi.AuthInfo{
 				Exec: &clientcmdapi.ExecConfig{
 					APIVersion: clientauth.SchemeGroupVersion.String(),
@@ -153,7 +157,7 @@ KUBECONFIG
 						"--config",
 						runtime.ConfigPath(),
 						"--account",
-						rt.AccountName(),
+						rt.Account().Name,
 						"kubernetes",
 						"cluster",
 						"exec-credential",

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -263,7 +263,7 @@ func NewTestRuntime() (*Runtime, error) {
 			Name:   "test",
 			UserID: "testId",
 			Token:  "testToken",
-			URL:    "testURL",
+			URL:    "testURL.example.com",
 		},
 		client: nil,
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -12,10 +12,8 @@ import (
 
 // Runtime holds all run-time infos.
 type Runtime struct {
-	account     AccountEntry
-	accountName string
-	client      interface{}
-	config      Config
+	account AccountEntry
+	client  interface{}
 }
 
 // KubernetesOperator amalgamates operations for Kubernetes PaaS.
@@ -40,11 +38,6 @@ func (r *Runtime) SetPaaSOperator(op gsclient.PaaSOperator) {
 	r.client = op
 }
 
-// AccountName is the current selected account.
-func (r *Runtime) AccountName() string {
-	return r.accountName
-}
-
 // Account is the current selected account.
 func (r *Runtime) Account() AccountEntry {
 	return r.account
@@ -53,11 +46,6 @@ func (r *Runtime) Account() AccountEntry {
 // Client provides access to the API client.
 func (r *Runtime) Client() *gsclient.Client {
 	return r.client.(*gsclient.Client)
-}
-
-// Config allows access to configuration.
-func (r *Runtime) Config() *Config {
-	return &r.config
 }
 
 // ServerIPRelationOperator return an operation to remove a storage.
@@ -245,10 +233,8 @@ func NewRuntime(conf Config, accountName string, commandWithoutConfig bool) (*Ru
 
 	client := newClient(ac)
 	rt := &Runtime{
-		account:     ac,
-		accountName: ac.Name,
-		client:      client,
-		config:      conf,
+		account: ac,
+		client:  client,
 	}
 	return rt, nil
 }
@@ -285,10 +271,8 @@ func NewTestRuntime() (*Runtime, error) {
 	}}
 
 	rt := &Runtime{
-		account:     testConfig.Accounts[0],
-		accountName: testConfig.Accounts[0].Name,
-		client:      nil,
-		config:      testConfig,
+		account: testConfig.Accounts[0],
+		client:  nil,
 	}
 	return rt, nil
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -45,6 +45,11 @@ func (r *Runtime) AccountName() string {
 	return r.accountName
 }
 
+// Account is the current selected account.
+func (r *Runtime) Account() *AccountEntry {
+	return r.account
+}
+
 // Client provides access to the API client.
 func (r *Runtime) Client() *gsclient.Client {
 	return r.client.(*gsclient.Client)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -40,8 +40,8 @@ func (r *Runtime) SetPaaSOperator(op gsclient.PaaSOperator) {
 	r.client = op
 }
 
-// Account is the current selected account.
-func (r *Runtime) Account() string {
+// AccountName is the current selected account.
+func (r *Runtime) AccountName() string {
 	return r.accountName
 }
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -12,6 +12,7 @@ import (
 
 // Runtime holds all run-time infos.
 type Runtime struct {
+	account     *AccountEntry
 	accountName string
 	client      interface{}
 	config      Config
@@ -239,6 +240,7 @@ func NewRuntime(conf Config, accountName string, commandWithoutConfig bool) (*Ru
 
 	client := newClient(ac)
 	rt := &Runtime{
+		account:     &conf.Accounts[accountIndex],
 		accountName: ac.Name,
 		client:      client,
 		config:      conf,
@@ -268,9 +270,20 @@ func LoadEnvVariables(defaultAc AccountEntry) AccountEntry {
 // NewTestRuntime creates a pretty useless runtime instance. Except maybe if
 // used for testing.
 func NewTestRuntime() (*Runtime, error) {
+	testConfig := Config{Accounts: []AccountEntry{
+		{
+			Name:   "test",
+			UserID: "testId",
+			Token:  "testToken",
+			URL:    "testURL",
+		},
+	}}
+
 	rt := &Runtime{
-		accountName: "test",
+		account:     &testConfig.Accounts[0],
+		accountName: testConfig.Accounts[0].Name,
 		client:      nil,
+		config:      testConfig,
 	}
 	return rt, nil
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -212,24 +212,21 @@ func (r *Runtime) SetServerStorageRelationOperator(op gsclient.ServerStorageRela
 // only one runtime instance in the program.
 func NewRuntime(conf Config, accountName string, commandWithoutConfig bool) (*Runtime, error) {
 	var ac AccountEntry
-	var accountIndex = -1
 
-	for i, a := range conf.Accounts {
+	for _, a := range conf.Accounts {
 		if accountName == a.Name {
 			ac = a
-			accountIndex = i
 			break
 		}
 	}
 
-	if accountIndex == -1 {
+	if (ac == AccountEntry{}) {
 		if len(conf.Accounts) > 0 && !commandWithoutConfig {
 			return nil, fmt.Errorf("account '%s' does not exist", accountName)
 		}
-	} else {
-		ac = LoadEnvVariables(ac)
-		conf.Accounts[accountIndex] = ac
 	}
+
+	ac = LoadEnvVariables(ac)
 
 	client := newClient(ac)
 	rt := &Runtime{
@@ -261,18 +258,14 @@ func LoadEnvVariables(defaultAc AccountEntry) AccountEntry {
 // NewTestRuntime creates a pretty useless runtime instance. Except maybe if
 // used for testing.
 func NewTestRuntime() (*Runtime, error) {
-	testConfig := Config{Accounts: []AccountEntry{
-		{
+	rt := &Runtime{
+		account: AccountEntry{
 			Name:   "test",
 			UserID: "testId",
 			Token:  "testToken",
 			URL:    "testURL",
 		},
-	}}
-
-	rt := &Runtime{
-		account: testConfig.Accounts[0],
-		client:  nil,
+		client: nil,
 	}
 	return rt, nil
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -12,7 +12,7 @@ import (
 
 // Runtime holds all run-time infos.
 type Runtime struct {
-	account     *AccountEntry
+	account     AccountEntry
 	accountName string
 	client      interface{}
 	config      Config
@@ -46,7 +46,7 @@ func (r *Runtime) AccountName() string {
 }
 
 // Account is the current selected account.
-func (r *Runtime) Account() *AccountEntry {
+func (r *Runtime) Account() AccountEntry {
 	return r.account
 }
 
@@ -245,7 +245,7 @@ func NewRuntime(conf Config, accountName string, commandWithoutConfig bool) (*Ru
 
 	client := newClient(ac)
 	rt := &Runtime{
-		account:     &conf.Accounts[accountIndex],
+		account:     ac,
 		accountName: ac.Name,
 		client:      client,
 		config:      conf,
@@ -285,7 +285,7 @@ func NewTestRuntime() (*Runtime, error) {
 	}}
 
 	rt := &Runtime{
-		account:     &testConfig.Accounts[0],
+		account:     testConfig.Accounts[0],
 		accountName: testConfig.Accounts[0].Name,
 		client:      nil,
 		config:      testConfig,

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -70,12 +70,9 @@ func Test_NewRuntime(t *testing.T) {
 		assert.Equal(t, test.ExpectedRuntimeIsNil, rt == nil)
 
 		if rt != nil {
-			for _, ac := range rt.config.Accounts {
-				if ac.Name == rt.accountName {
-					assert.Equal(t, test.ExpectedAccount, ac)
-					break
-				}
-			}
+			assert.NotNil(t, rt.account)
+
+			assert.Equal(t, test.ExpectedAccount, *rt.account)
 		}
 
 		resetEnv(oldEnviron)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -70,8 +70,6 @@ func Test_NewRuntime(t *testing.T) {
 		assert.Equal(t, test.ExpectedRuntimeIsNil, rt == nil)
 
 		if rt != nil {
-			assert.NotNil(t, rt.account)
-
 			assert.Equal(t, test.ExpectedAccount, rt.account)
 		}
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -72,7 +72,7 @@ func Test_NewRuntime(t *testing.T) {
 		if rt != nil {
 			assert.NotNil(t, rt.account)
 
-			assert.Equal(t, test.ExpectedAccount, *rt.account)
+			assert.Equal(t, test.ExpectedAccount, rt.account)
 		}
 
 		resetEnv(oldEnviron)


### PR DESCRIPTION
Before, accountName and config were saved, and to get the account you had to manually search for the right account in the config. Now the config and accountName are no longer saved in Runtime, because they're not used anywhere in the program, and instead the account is saved in Runtime