### PR TITLE
Only close channel after tasks have finished

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -132,11 +132,6 @@ Show summary for a given account:
 				var wg sync.WaitGroup
 				ch := make(chan objectCount)
 
-				go func() {
-					wg.Wait()
-					close(ch)
-				}()
-
 				for k, v := range funcs {
 					wg.Add(1)
 					cCopy := context.Background()
@@ -150,6 +145,11 @@ Show summary for a given account:
 						ch <- objectCount{obj, agg, nil}
 					}(k, v)
 				}
+
+				go func() {
+					wg.Wait()
+					close(ch)
+				}()
 
 				out := new(bytes.Buffer)
 				if !rootFlags.json {


### PR DESCRIPTION
The old implementation relied on the first wg.Add(1) to be called before
wg.Wait(), or else the channel could be closed before the tasks even
started. This probably never happened because calling go-routines is
slower than starting the loop, but if anything had been put inbetween,
this would've failed to load the data