### PR TITLE
Fix error "config not found" when exec cmd that doesn't need config & fix some docs and warning messages 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [here](docs/source.md) on how to build gscloud from source.
 You can use `gscloud make-config` to generate a new config file. Make sure to add your user ID and API token here.
 
 Default locations:
-- Linux: `~/.kube/config`
+- Linux: `$XDG_CONFIG_HOME/gridscale/config.yaml` or `$HOME/.config/gridscale/config.yaml`
 - Mac: `~/Library/Application Support/gscloud/config.yaml`
 - Windows: `%APPDATA%` or `"C:\\Users\\%USER%\\AppData\\Roaming"`
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -193,6 +193,9 @@ func exists(path string) bool {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+	if CommandWithoutConfig(os.Args) {
+		return
+	}
 	if rootFlags.configFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(rootFlags.configFile)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -206,7 +206,7 @@ func initConfig() {
 
 		if !exists(runtime.ConfigPath()) && exists(runtime.OldConfigPath()) && !CommandWithoutConfig(os.Args) {
 			viper.SetConfigFile(filepath.Join(runtime.OldConfigPath(), "config.yaml"))
-			log.Warnln("Using deprecated old config file. Use `gscloud make-config --move` to move to the new one")
+			log.Warnln("Using deprecated old config file. Use `gscloud move-config` to move to the new one")
 		} else {
 			viper.AddConfigPath(runtime.ConfigPath())
 			viper.AddConfigPath(runtime.OldConfigPath())


### PR DESCRIPTION
Changes:
- Skip `initConfig` when executing the command that doesn't need config, i.e. `make-config`, `version`, `manpage`, `completion`, `move-config`.
- Correct docs regarding the default locations of the config file for linux.
- Correct warning message regarding "deprecated old config file".