### PR TITLE
fix windows file access handling

### DIFF
--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -347,9 +347,7 @@ func loadCachedKubeConfig(id string) (*clientauth.ExecCredential, error) {
 		return nil, err
 	}
 
-	defer func() {
-		_ = f.Close()
-	}()
+	defer f.Close()
 
 	var execCredential *clientauth.ExecCredential
 	if err := json.NewDecoder(f).Decode(&execCredential); err != nil {


### PR DESCRIPTION
On Windows, you cannot delete a file that is in use. With defer, the file is only closed after the function is executed. The fix ensures that the file is closed before deletion and otherwise closes the file with defer after the function, without throwing an error, when it is closed.
fixed #140 too