### PR TITLE
Add Docker container that is automatically build for releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,41 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Create RELEASE.txt
+        run: |
+          echo "GIT_COMMIT=${{ github.sha }}" > RELEASE.txt
+          echo "VERSION=${{ github.ref_name }}" >> RELEASE.txt
+          cat RELEASE.txt
+
+      - name: Login to GitHub registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ github.actor }}
+          password:  ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+      
+      - name: Build and push Docker container to GitHub registry
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          labels: |
+            git_commit=${{ github.sha }}
+            version=${{ github.ref_name }}
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:alpine
+
+COPY . /src
+
+RUN cd /src && \
+    apk add --no-cache make git && \
+    make
+
+FROM alpine:latest
+
+COPY --from=0 /src/gscloud /usr/bin/gscloud
+ENTRYPOINT ["/usr/bin/gscloud"]

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 VERSION := $(shell if ! git describe --tags 2>/dev/null; then \
-	grep -Po '(?<=^VERSION=)v.*$$' $$PWD/RELEASE.txt; \
+	grep '^VERSION=' $$PWD/RELEASE.txt|cut -d'=' -f2-; \
 fi; \
 )
 
 GIT_COMMIT := $(shell if ! git rev-list -1 HEAD 2>/dev/null; then \
-	grep -Po '(?<=^GIT_COMMIT=)\w*$$' $$PWD/RELEASE.txt; \
+	grep '^GIT_COMMIT=' $$PWD/RELEASE.txt|cut -d'=' -f2-; \
 fi; \
 )
 


### PR DESCRIPTION
I need a gscloud docker container for something I'm working on right now and I thought this might be useful to do upstream, so others also benefit from this work.

This adds the following changes:
- Whenever a tag is created, build a docker container
- Tag this container as both latest and the tag name
- Push both tags to the Docker registry on this GitHub repo

The container has gscloud as entrypoint. Here is a quick example on how you'd use it:
```
$ docker run -ti --rm ghcr.io/sharkwouter/gscloud:latest version
Version:        test13
Git commit:     1abd35253f6ed698f4db4c3d1ac206279e0156c9
```