### PR TITLE
Also push container to Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,3 +39,23 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        if: github.repository_owner == 'gridscale'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v5
+        if: github.repository_owner == 'gridscale'
+        with:
+          context: .
+          push: true
+          labels: |
+            git_commit=${{ github.sha }}
+            version=${{ github.ref_name }}
+          tags: |
+            ${{ github.repository }}:latest
+            ${{ github.repository }}:${{ github.ref_name }}


### PR DESCRIPTION
This change will require some secrets to be added before merging. I'll update when this has been done.

The Docker Hub push will not happen for any other repo than the one in the gridscale organization.