### PR TITLE
Document --config flag explicitly in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,19 @@ projects:
   url: https://api.gridscale.io
 ```
 
+You can specify a custom location for the config file by using the `--config` flag, which
+allows you to keep multiple configs per project or environment. For example:
+
+```shelld
+gscloud --config production.yml info
+gscloud --config staging.yml info
+```
+
 Following environment variables can also be used instead of config file:
 - `GRIDSCALE_UUID` - corresponds to `userId`
 - `GRIDSCALE_TOKEN` - corresponds to `token`
 - `GRIDSCALE_URL` - corresponds to `url`
+
 **Note**: If the config file and the environment variables are used at the same time, the config file will be ignored and the environment variables will be used.
 
 ## Kubernetes


### PR DESCRIPTION
When using the CLI, i found myself missing an equivalent to how tools like `kubectl` can be configured to use a different config:

```shell
KUBECONFIG=production.yml kubectl get nodes
```

When searching for a similar option, i found the `--config` flag.

With this commit I want to explicitly document that flag so that other users may find this option too.